### PR TITLE
feat: fix c_, r_

### DIFF
--- a/src/quaxed/numpy/_core.py
+++ b/src/quaxed/numpy/_core.py
@@ -544,7 +544,6 @@ _DIRECT_TRANSFER: frozenset[str] = frozenset(
         "pi",
         "printoptions",
         "promote_types",
-        "r_",
         "s_",
         "set_printoptions",
         "signedinteger",

--- a/src/quaxed/numpy/_core.py
+++ b/src/quaxed/numpy/_core.py
@@ -411,6 +411,7 @@ from collections.abc import Callable
 from typing import Any, Literal, TypeVar
 
 import jax.numpy as jnp
+from jax._src.numpy.index_tricks import CClass, RClass
 from jaxtyping import ArrayLike
 
 from quaxed._types import DType
@@ -454,6 +455,47 @@ def expand_dims(a: ArrayLike, axis: int | tuple[int, ...]) -> ArrayLike:
 @_set_docstring(jnp.squeeze.__doc__)
 def squeeze(a: ArrayLike, axis: int | tuple[int, ...] | None = None) -> ArrayLike:
     return jnp.squeeze(a, axis=axis)
+
+
+class QuaxedCClass(CClass):  # type: ignore[misc]
+    """Quaxed version of `jax.numpy.CClass`.
+
+    Examples
+    --------
+    >>> import quaxed.numpy as jnp
+    >>> x = jnp.asarray(jnp.linspace(0, 11, 11), dtype=int)
+    >>> jnp.c_[x, x].T
+    Array([[ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 11],
+           [ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 11]], dtype=int32)
+
+    """
+
+    @quaxify
+    def __getitem__(self, key: Any) -> Any:
+        return super().__getitem__(key)
+
+
+c_ = QuaxedCClass()
+
+
+class QuaxedRClass(RClass):  # type: ignore[misc]
+    """Quaxed version of `jax.numpy.RClass`.
+
+    Examples
+    --------
+    >>> import quaxed.numpy as jnp
+    >>> x = jnp.asarray(jnp.linspace(0, 4, 4), dtype=int)
+    >>> jnp.r_[x, x]
+    Array([0, 1, 2, 4, 0, 1, 2, 4], dtype=int32)
+
+    """
+
+    @quaxify
+    def __getitem__(self, key: Any) -> Any:
+        return super().__getitem__(key)
+
+
+r_ = QuaxedRClass()
 
 
 # =============================================================================

--- a/tests/numpy/test_jax.py
+++ b/tests/numpy/test_jax.py
@@ -384,7 +384,6 @@ def test_broadcast_to(x1):
     assert jnp.all(qnp.broadcast_to(x1, (3, 3)) == jnp.broadcast_to(x1, (3, 3)))
 
 
-@pytest.mark.xfail(reason="Not implemented.")
 def test_c_():
     """Test `quaxed.numpy.c_`."""
     assert jnp.all(qnp.c_[1:3, 4:6] == jnp.c_[1:3, 4:6])


### PR DESCRIPTION
This pull request to `src/quaxed/numpy/_core.py` introduces new classes to provide Quaxed versions of `jax.numpy` classes and imports necessary dependencies. The most important changes include adding the `QuaxedCClass` and `QuaxedRClass` with their respective methods and examples.

New classes and methods:

* Added `QuaxedCClass` to provide a Quaxed version of `jax.numpy.CClass`, including the `__getitem__` method decorated with `@quaxify`. (`src/quaxed/numpy/_core.py`)
* Added `QuaxedRClass` to provide a Quaxed version of `jax.numpy.RClass`, including the `__getitem__` method decorated with `@quaxify`. (`src/quaxed/numpy/_core.py`)

Dependency imports:

* Imported `CClass` and `RClass` from `jax._src.numpy.index_tricks` to support the new Quaxed classes. (`src/quaxed/numpy/_core.py`)