### PR TITLE
Subclasses for Arrayish Objects

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,7 +81,7 @@ repos:
       - id: mypy
         files: src
         additional_dependencies:
-          - pytest
+          - optype
         exclude: |
           (?x)^(
             src/quaxed/lax/__init__.py|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -111,4 +111,4 @@ repos:
         name: Disallow improper capitalization
         language: pygrep
         entry: PyBind|Numpy|Cmake|CCache|Github|PyTest
-        exclude: .pre-commit-config.yaml
+        exclude: .pre-commit-config.yaml|src/quaxed/experimental/arrayish.py|src/quaxed/experimental/_arrayish

--- a/docs/api/arrayish.md
+++ b/docs/api/arrayish.md
@@ -1,0 +1,3 @@
+# quaxed.experimental.arrayish
+
+::: quaxed.experimental.arrayish

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,3 +102,4 @@ nav:
       - "api/scipy.md"
       - "api/array_api.md"
       - "api/lax.md"
+      - "api/arrayish.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,10 @@
     "jax>=0.4.3",
     "jaxlib>=0.4.3",
     "jaxtyping>=0.2.34",
+    "optype>=0.8.0",
     "plum-dispatch>=2.5.2",
     "quax>=0.0.5",
-  ]
+]
 
   [project.urls]
     Homepage = "https://github.com/GalacticDynamics/quaxed"

--- a/src/quaxed/__init__.py
+++ b/src/quaxed/__init__.py
@@ -1,43 +1,38 @@
-"""Quaxified `jax.scipy`.
+"""Pre-`quaxify`ed jax and related libraries.
 
-This module wraps the functions in `jax.lax` with `quax.quaxify`. The wrapping
-happens dynamically through a module-level ``__dir__`` and ``__getattr__``. The
-list of available functions is in ``__all__`` and documented in the `jax.lax`
-library.
-
-In addition the following modules are supported:
-
-- `quaxed.lax.linalg`
-
-The contents of these modules are likewise dynamically wrapped with
-`quax.quaxify` and their contents is listed in their respective ``__all__`` and
-documented in their respective libraries.
-
-If a function is missing, please file an Issue.
+`quax` is JAX + multiple dispatch + custom array-ish objects. `quaxed` is a
+drop-in replacement for many JAX and related libraries that applies
+`quax.quaxify` to the original JAX functions, enabling custom array-ish objects
+to be used with those functions, not only jax arrays.
 
 """
-# pylint: disable=C0415,W0621
 
-from __future__ import annotations
+__all__ = [
+    # Modules
+    "lax",
+    "numpy",
+    "scipy",
+    "experimental",
+    # Jax functions
+    "device_put",
+    "grad",
+    "hessian",
+    "jacfwd",
+    "jacrev",
+    "value_and_grad",
+]
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
-from . import _jax, lax, numpy, scipy
-from ._jax import *
+from . import experimental, lax, numpy, scipy
+from ._jax import device_put, grad, hessian, jacfwd, jacrev, value_and_grad
 from ._setup import JAX_VERSION
 from ._version import version as __version__  # noqa: F401
-
-__all__ = ["lax", "numpy", "scipy"]
-__all__ += _jax.__all__
 
 if JAX_VERSION < (0, 4, 32):
     from . import array_api
 
     __all__ += ["array_api"]
-
-
-if TYPE_CHECKING:
-    from typing import Any
 
 
 def __getattr__(name: str) -> Any:  # TODO: fuller annotation
@@ -59,4 +54,4 @@ def __getattr__(name: str) -> Any:  # TODO: fuller annotation
 
 
 # Clean up the namespace
-del TYPE_CHECKING
+del TYPE_CHECKING, Any

--- a/src/quaxed/experimental/__init__.py
+++ b/src/quaxed/experimental/__init__.py
@@ -1,0 +1,1 @@
+"""Experimental modules."""

--- a/src/quaxed/experimental/_arrayish/__init__.py
+++ b/src/quaxed/experimental/_arrayish/__init__.py
@@ -1,0 +1,3 @@
+"""Arrayish."""
+
+__all__: list[str] = []

--- a/src/quaxed/experimental/_arrayish/binary.py
+++ b/src/quaxed/experimental/_arrayish/binary.py
@@ -1,0 +1,1814 @@
+"""Binary operations for Array-ish objects."""
+
+# fmt: off
+__all__ = [
+    "LaxBinaryOpsMixin", "NumpyBinaryOpsMixin",
+    # ========== Float Operations ==========
+    "LaxMathMixin", "NumpyMathMixin",
+    # ----- add -----
+    "LaxBothAddMixin", "NumpyBothAddMixin",
+    "LaxAddMixin", "NumpyAddMixin",  # __add__
+    "LaxRAddMixin", "NumpyRAddMixin",  # __radd__
+    # ----- sub -----
+    "LaxBothSubMixin", "NumpyBothSubMixin",
+    "LaxSubMixin", "NumpySubMixin",  # __sub__
+    "LaxRSubMixin", "NumpyRSubMixin",  # __rsub__
+    # ----- mul -----
+    "LaxBothMulMixin", "NumpyBothMulMixin",
+    "LaxMulMixin", "NumpyMulMixin",  # __mul__
+    "LaxRMulMixin", "NumpyRMulMixin",  # __rmul__
+    # ---- matmul -----
+    "LaxMatMulMixin", "NumpyMatMulMixin",  # __matmul__
+    # "LaxRMatMulMixin", "NumpyRMatMulMixin",  # __rmatmul__
+    # ----- truediv -----
+    "LaxBothTrueDivMixin", "NumpyBothTrueDivMixin",
+    "LaxTrueDivMixin", "NumpyTrueDivMixin",  # __truediv__
+    "LaxRTrueDivMixin", "NumpyRTrueDivMixin",  # __rtruediv__
+    # ----- floordiv -----
+    "LaxBothFloorDivMixin", "NumpyBothFloorDivMixin",
+    "LaxFloorDivMixin", "NumpyFloorDivMixin",  # __floordiv__
+    "LaxRFloorDivMixin", "NumpyRFloorDivMixin",  # __rfloordiv__
+    # ----- mod -----
+    "LaxBothModMixin", "NumpyBothModMixin",
+    "LaxModMixin", "NumpyModMixin",  # __mod__
+    "LaxRModMixin", "NumpyRModMixin",  # __rmod__
+    # ----- divmod -----
+    "NumpyBothDivModMixin",
+    # "LaxDivModMixin",
+    "NumpyDivModMixin",
+    # "LaxRDivModMixin",
+    "NumpyRDivModMixin",
+    # ----- pow -----
+    "LaxBothPowMixin", "NumpyBothPowMixin",
+    "LaxPowMixin", "NumpyPowMixin",  # __pow__
+    "LaxRPowMixin", "NumpyRPowMixin",  # __rpow__
+    # ========== Bitwise Operations ==========
+    "LaxBitwiseMixin", "NumpyBitwiseMixin",
+    # ----- lshift -----
+    "LaxBothLShiftMixin", "NumpyBothLShiftMixin",
+    "LaxLShiftMixin", "NumpyLShiftMixin",  # __lshift__
+    "LaxRLShiftMixin", "NumpyRLShiftMixin",  # __rlshift__
+    # ----- rshift -----
+    "LaxBothRShiftMixin", "NumpyBothRShiftMixin",
+    "LaxRShiftMixin", "NumpyRShiftMixin",  # __rshift__
+    "LaxRRShiftMixin", "NumpyRRShiftMixin",  # __rrshift__
+    # ----- and -----
+    "LaxBothAndMixin", "NumpyBothAndMixin",
+    "LaxAndMixin", "NumpyAndMixin",  # __and__
+    "LaxRAndMixin", "NumpyRAndMixin",  # __rand__
+    # ----- xor -----
+    "LaxBothXorMixin", "NumpyBothXorMixin",
+    "LaxXorMixin", "NumpyXorMixin",  # __xor__
+    "LaxRXorMixin", "NumpyRXorMixin",  # __rxor__
+    # ----- or -----
+    "LaxBothOrMixin", "NumpyBothOrMixin",
+    "LaxOrMixin", "NumpyOrMixin",  # __or__
+    "LaxROrMixin", "NumpyROrMixin", # __ror__
+]
+# fmt: on
+
+from typing import Generic, Literal
+from typing_extensions import TypeVar
+
+import quaxed.lax as qlax
+import quaxed.numpy as qnp
+
+T = TypeVar("T")
+R = TypeVar("R", default=bool)
+
+
+# ===============================================
+# Add
+
+# -------------------------------------
+# `__add__`
+
+
+class LaxAddMixin(Generic[T, R]):
+    """Mixin for ``__add__`` method using quaxified `jax.lax.add`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array, Bool
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, LaxAddMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> x + x
+    Array([2, 4, 6], dtype=int32)
+
+    """  # noqa: E501
+
+    def __add__(self, other: T) -> R:
+        return qlax.add(self, other)
+
+
+class NumpyAddMixin(Generic[T, R]):
+    """Mixin for ``__add__`` method using quaxified `jax.numpy.add`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array, Bool
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpyAddMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> x + x
+    Array([2, 4, 6], dtype=int32)
+
+    """  # noqa: E501
+
+    def __add__(self, other: T) -> R:
+        return qnp.add(self, other)
+
+
+# -------------------------------------
+# `__radd__`
+
+
+class LaxRAddMixin(Generic[T, R]):
+    """Mixin for ``__radd__`` method using quaxified `jax.lax.add`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array, Bool
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, LaxRAddMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> 1 + x
+    Array([2, 3, 4], dtype=int32)
+
+    """  # noqa: E501
+
+    def __radd__(self, other: T) -> R:
+        return qlax.add(other, self)
+
+
+class NumpyRAddMixin(Generic[T, R]):
+    """Mixin for ``__radd__`` method using quaxified `jax.numpy.add`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array, Bool
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpyRAddMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> 1 + x
+    Array([2, 3, 4], dtype=int32)
+
+    """  # noqa: E501
+
+    def __radd__(self, other: T) -> R:
+        return qnp.add(other, self)
+
+
+# -------------------------------------
+
+
+class LaxBothAddMixin(LaxAddMixin[T, R], LaxRAddMixin[T, R]):
+    pass
+
+
+class NumpyBothAddMixin(NumpyAddMixin[T, R], NumpyRAddMixin[T, R]):
+    pass
+
+
+# ===============================================
+# Subtraction
+
+# -------------------------------------
+# `__sub__`
+
+
+class LaxSubMixin(Generic[T, R]):
+    """Mixin for ``__sub__`` method using quaxified `jax.lax.sub`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array, Bool
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, LaxSubMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> x - x
+    Array([0, 0, 0], dtype=int32)
+
+    """  # noqa: E501
+
+    def __sub__(self, other: T) -> R:
+        return qlax.sub(self, other)
+
+
+class NumpySubMixin(Generic[T, R]):
+    """Mixin for ``__sub__`` method using quaxified `jax.numpy.sub`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array, Bool
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpySubMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> x - x
+    Array([0, 0, 0], dtype=int32)
+
+    """  # noqa: E501
+
+    def __sub__(self, other: T) -> R:
+        return qnp.subtract(self, other)
+
+
+# -------------------------------------
+# `__rsub__`
+
+
+class LaxRSubMixin(Generic[T, R]):
+    """Mixin for ``__rsub__`` method using quaxified `jax.lax.sub`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array, Bool
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, LaxRSubMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> 1 - x
+    Array([ 0, -1, -2], dtype=int32)
+
+    """  # noqa: E501
+
+    def __rsub__(self, other: T) -> R:
+        return qlax.sub(other, self)
+
+
+class NumpyRSubMixin(Generic[T, R]):
+    """Mixin for ``__rsub__`` method using quaxified `jax.numpy.sub`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array, Bool
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpyRSubMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> 1 - x
+    Array([ 0, -1, -2], dtype=int32)
+
+    """  # noqa: E501
+
+    def __rsub__(self, other: T) -> R:
+        return qnp.subtract(other, self)
+
+
+# -------------------------------------
+
+
+class LaxBothSubMixin(LaxSubMixin[T, R], LaxRSubMixin[T, R]):
+    pass
+
+
+class NumpyBothSubMixin(NumpySubMixin[T, R], NumpyRSubMixin[T, R]):
+    pass
+
+
+# ===============================================
+
+# -------------------------------------
+# `__mul__`
+
+
+class LaxMulMixin(Generic[T, R]):
+    """Mixin for ``__mul__`` method using quaxified `jax.lax.mul`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, LaxMulMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> x * x
+    Array([1, 4, 9], dtype=int32)
+
+    """  # noqa: E501
+
+    def __mul__(self, other: T) -> R:
+        return qlax.mul(self, other)
+
+
+class NumpyMulMixin(Generic[T, R]):
+    """Mixin for ``__mul__`` method using quaxified `jax.numpy.mul`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpyMulMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> x * x
+    Array([1, 4, 9], dtype=int32)
+
+    """  # noqa: E501
+
+    def __mul__(self, other: T) -> R:
+        return qnp.multiply(self, other)
+
+
+# -------------------------------------
+# `__rmul__`
+
+
+class LaxRMulMixin(Generic[T, R]):
+    """Mixin for ``__rmul__`` method using quaxified `jax.lax.mul`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, LaxRMulMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> 2 * x
+    Array([2, 4, 6], dtype=int32)
+
+    """  # noqa: E501
+
+    def __rmul__(self, other: T) -> R:
+        return qlax.mul(other, self)
+
+
+class NumpyRMulMixin(Generic[T, R]):
+    """Mixin for ``__rmul__`` method using quaxified `jax.numpy.mul`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpyRMulMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> 2 * x
+    Array([2, 4, 6], dtype=int32)
+
+    """  # noqa: E501
+
+    def __rmul__(self, other: T) -> R:
+        return qnp.multiply(other, self)
+
+
+# -------------------------------------
+
+
+class LaxBothMulMixin(LaxMulMixin[T, R], LaxRMulMixin[T, R]):
+    pass
+
+
+class NumpyBothMulMixin(NumpyMulMixin[T, R], NumpyRMulMixin[T, R]):
+    pass
+
+
+# ===============================================
+
+# -------------------------------------
+# `__matmul__`
+
+
+class LaxMatMulMixin(Generic[T, R]):
+    """Mixin for ``__matmul__`` method using quaxified `jax.lax.matmul`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, LaxMatMulMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([[1, 2], [3, 4]]))
+    >>> y = MyArray(jnp.array([[5, 6], [7, 8]]))
+    >>> x @ y
+    Array([[19, 22],
+           [43, 50]], dtype=int32)
+
+    """  # noqa: E501
+
+    def __matmul__(self, other: T) -> R:
+        return qlax.dot(self, other)  # TODO: is this the right operator?
+
+
+class NumpyMatMulMixin(Generic[T, R]):
+    """Mixin for ``__matmul__`` method using quaxified `jax.numpy.matmul`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpyMatMulMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([[1, 2], [3, 4]]))
+    >>> y = MyArray(jnp.array([[5, 6], [7, 8]]))
+    >>> x @ y
+    Array([[19, 22],
+           [43, 50]], dtype=int32)
+
+    """  # noqa: E501
+
+    def __matmul__(self, other: T) -> R:
+        return qnp.matmul(self, other)
+
+
+# ===============================================
+# Float Division
+
+# -------------------------------------
+# `__truediv__`
+
+
+class LaxTrueDivMixin(Generic[T, R]):
+    """Mixin for ``__truediv__`` method using quaxified `jax.lax.truediv`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, LaxTrueDivMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> x / 2  # Note: integer division
+    Array([0, 1, 1], dtype=int32)
+
+    """  # noqa: E501
+
+    def __truediv__(self, other: T) -> R:
+        return qlax.div(self, other)
+
+
+class NumpyTrueDivMixin(Generic[T, R]):
+    """Mixin for ``__truediv__`` method using quaxified `jax.numpy.true_divide`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpyTrueDivMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> x / 2
+    Array([0.5, 1. , 1.5], dtype=float32)
+
+    """  # noqa: E501
+
+    def __truediv__(self, other: T) -> R:
+        return qnp.true_divide(self, other)
+
+
+# -------------------------------------
+# `__rtruediv__`
+
+
+class LaxRTrueDivMixin(Generic[T, R]):
+    """Mixin for ``__rtruediv__`` method using quaxified `jax.lax.truediv`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, LaxRTrueDivMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> 2 / x
+    Array([2, 1, 0], dtype=int32)
+
+    """  # noqa: E501
+
+    def __rtruediv__(self, other: T) -> R:
+        return qlax.div(other, self)
+
+
+class NumpyRTrueDivMixin(Generic[T, R]):
+    """Mixin for ``__rtruediv__`` method using quaxified `jax.numpy.true_divide`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpyRTrueDivMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> 2 / x
+    Array([2. , 1. , 0.6666667], dtype=float32)
+
+    """  # noqa: E501
+
+    def __rtruediv__(self, other: T) -> R:
+        return qnp.true_divide(other, self)
+
+
+# -------------------------------------
+
+
+class LaxBothTrueDivMixin(LaxTrueDivMixin[T, R], LaxRTrueDivMixin[T, R]):
+    pass
+
+
+class NumpyBothTrueDivMixin(NumpyTrueDivMixin[T, R], NumpyRTrueDivMixin[T, R]):
+    pass
+
+
+# ===============================================
+# Integer Division
+
+# -------------------------------------
+# Floor division
+
+
+class LaxFloorDivMixin(Generic[T, R]):
+    """Mixin for ``__floordiv__`` method using quaxified `jax.lax`.
+
+    Note that lax does not have a floor division function, so this is
+    ``lax.floor(lax.div(x, y))``.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, LaxFloorDivMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1., 2, 3]))
+    >>> x // 2.
+    Array([0., 1., 1.], dtype=float32)
+
+    """  # noqa: E501
+
+    def __floordiv__(self, other: T) -> R:
+        return qlax.floor(qlax.div(self, other))
+
+
+class NumpyFloorDivMixin(Generic[T, R]):
+    """Mixin for ``__floordiv__`` method using quaxified `jax.numpy.floor_divide`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpyFloorDivMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> x // 2
+    Array([0, 1, 1], dtype=int32)
+
+    """  # noqa: E501
+
+    def __floordiv__(self, other: T) -> R:
+        return qnp.floor_divide(self, other)
+
+
+# -------------------------------------
+# `__rfloordiv__`
+
+
+class LaxRFloorDivMixin(Generic[T, R]):
+    """Mixin for ``__rfloordiv__`` method using quaxified `jax.lax`.
+
+    Note that lax does not have a floor division function, so this is
+    ``lax.floor(lax.div(x, y))``.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, LaxRFloorDivMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1., 2, 3]))
+    >>> 2. // x
+    Array([2., 1., 0.], dtype=float32)
+
+    """  # noqa: E501
+
+    def __rfloordiv__(self, other: T) -> R:
+        return qlax.floor(qlax.div(other, self))
+
+
+class NumpyRFloorDivMixin(Generic[T, R]):
+    """Mixin for ``__rfloordiv__`` method using quaxified `jax.numpy.floor_divide`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpyRFloorDivMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> 2 // x
+    Array([2, 1, 0], dtype=int32)
+
+    """  # noqa: E501
+
+    def __rfloordiv__(self, other: T) -> R:
+        return qnp.floor_divide(other, self)
+
+
+# -------------------------------------
+
+
+class LaxBothFloorDivMixin(LaxFloorDivMixin[T, R], LaxRFloorDivMixin[T, R]):
+    pass
+
+
+class NumpyBothFloorDivMixin(NumpyFloorDivMixin[T, R], NumpyRFloorDivMixin[T, R]):
+    pass
+
+
+# ===============================================
+# Modulus
+
+# -------------------------------------
+# `__mod__`
+
+
+class LaxModMixin(Generic[T, R]):
+    """Mixin for ``__mod__`` method using quaxified `jax.lax.rem`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, LaxModMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> x % 2
+    Array([1, 0, 1], dtype=int32)
+
+    """  # noqa: E501
+
+    def __mod__(self, other: T) -> R:
+        return qlax.rem(self, other)
+
+
+class NumpyModMixin(Generic[T, R]):
+    """Mixin for ``__mod__`` method using quaxified `jax.numpy.mod`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpyModMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> x % 2
+    Array([1, 0, 1], dtype=int32)
+
+    """  # noqa: E501
+
+    def __mod__(self, other: T) -> R:
+        return qnp.mod(self, other)
+
+
+# -------------------------------------
+# `__rmod__`
+
+
+class LaxRModMixin(Generic[T, R]):
+    """Mixin for ``__rmod__`` method using quaxified `jax.lax.rem`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, LaxRModMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> 2 % x
+    Array([0, 0, 2], dtype=int32)
+
+    """  # noqa: E501
+
+    def __rmod__(self, other: T) -> R:
+        return qlax.rem(other, self)
+
+
+class NumpyRModMixin(Generic[T, R]):
+    """Mixin for ``__rmod__`` method using quaxified `jax.numpy.mod`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpyRModMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> 2 % x
+    Array([0, 0, 2], dtype=int32)
+
+    """  # noqa: E501
+
+    def __rmod__(self, other: T) -> R:
+        return qnp.mod(other, self)
+
+
+# -------------------------------------
+
+
+class LaxBothModMixin(LaxModMixin[T, R], LaxRModMixin[T, R]):
+    pass
+
+
+class NumpyBothModMixin(NumpyModMixin[T, R], NumpyRModMixin[T, R]):
+    pass
+
+
+# ===============================================
+# Divmod
+
+# -------------------------------------
+# `__divmod__`
+
+
+# TODO: a jax.lax.divmod equivalent?
+
+
+class NumpyDivModMixin(Generic[T, R]):
+    """Mixin for ``__divmod__`` method using quaxified `jax.numpy.divmod`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpyDivModMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([5, 7, 9]))
+    >>> divmod(x, 2)
+    (Array([2, 3, 4], dtype=int32), Array([1, 1, 1], dtype=int32))
+
+    """  # noqa: E501
+
+    def __divmod__(self, other: T) -> R:
+        return qnp.divmod(self, other)
+
+
+# -------------------------------------
+# `__rdivmod__`
+
+
+# TODO: a jax.lax.divmod equivalent?
+
+
+class NumpyRDivModMixin(Generic[T, R]):
+    """Mixin for ``__rdivmod__`` method using quaxified `jax.numpy.divmod`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpyRDivModMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([5, 7, 9]))
+    >>> divmod(20, x)
+    (Array([4, 2, 2], dtype=int32), Array([0, 6, 2], dtype=int32))
+
+    """  # noqa: E501
+
+    def __rdivmod__(self, other: T) -> R:
+        return qnp.divmod(other, self)
+
+
+# -------------------------------------
+
+
+class NumpyBothDivModMixin(NumpyDivModMixin[T, R], NumpyRDivModMixin[T, R]):
+    pass
+
+
+# ===============================================
+# Power
+
+# -------------------------------------
+# `__pow__`
+
+
+class LaxPowMixin(Generic[T, R]):
+    """Mixin for ``__pow__`` method using quaxified `jax.lax.pow`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, LaxPowMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1., 2, 3]))  # must be floating
+    >>> x ** 2
+    Array([1., 4., 9.], dtype=float32)
+
+    """  # noqa: E501
+
+    def __pow__(self, other: T) -> R:
+        return qlax.pow(self, other)
+
+
+class NumpyPowMixin(Generic[T, R]):
+    """Mixin for ``__pow__`` method using quaxified `jax.numpy.pow`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpyPowMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> x ** 2
+    Array([1, 4, 9], dtype=int32)
+
+    """  # noqa: E501
+
+    def __pow__(self, other: T) -> R:
+        return qnp.power(self, other)
+
+
+# -------------------------------------
+# `__rpow__`
+
+
+class LaxRPowMixin(Generic[T, R]):
+    """Mixin for ``__rpow__`` method using quaxified `jax.lax.pow`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, LaxRPowMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> 2. ** x
+    Array([2., 4., 8.], dtype=float32)
+
+    """  # noqa: E501
+
+    def __rpow__(self, other: T) -> R:
+        return qlax.pow(other, self)
+
+
+class NumpyRPowMixin(Generic[T, R]):
+    """Mixin for ``__rpow__`` method using quaxified `jax.numpy.pow`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpyRPowMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> 2 ** x
+    Array([2, 4, 8], dtype=int32)
+
+    """  # noqa: E501
+
+    def __rpow__(self, other: T) -> R:
+        return qnp.power(other, self)
+
+
+# -------------------------------------
+
+
+class LaxBothPowMixin(LaxPowMixin[T, R], LaxRPowMixin[T, R]):
+    pass
+
+
+class NumpyBothPowMixin(NumpyPowMixin[T, R], NumpyRPowMixin[T, R]):
+    pass
+
+
+# ===============================================
+# Left Shift
+
+# -------------------------------------
+# `__lshift__`
+
+
+class LaxLShiftMixin(Generic[T, R]):
+    """Mixin for ``__lshift__`` method using quaxified `jax.lax.lshift`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, LaxLShiftMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> x << 1
+    Array([2, 4, 6], dtype=int32)
+
+    """  # noqa: E501
+
+    def __lshift__(self, other: T) -> R:
+        return qlax.shift_left(self, other)
+
+
+class NumpyLShiftMixin(Generic[T, R]):
+    """Mixin for ``__lshift__`` method using quaxified `jax.numpy.lshift`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpyLShiftMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> x << 1
+    Array([2, 4, 6], dtype=int32)
+
+    """  # noqa: E501
+
+    def __lshift__(self, other: T) -> R:
+        return qnp.left_shift(self, other)
+
+
+# -------------------------------------
+# `__rlshift__`
+
+
+class LaxRLShiftMixin(Generic[T, R]):
+    """Mixin for ``__rlshift__`` method using quaxified `jax.lax.lshift`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, LaxRLShiftMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> 1 << x
+    Array([2, 4, 8], dtype=int32)
+
+    """  # noqa: E501
+
+    def __rlshift__(self, other: T) -> R:
+        return qlax.shift_left(other, self)
+
+
+class NumpyRLShiftMixin(Generic[T, R]):
+    """Mixin for ``__rlshift__`` method using quaxified `jax.numpy.lshift`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpyRLShiftMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> 1 << x
+    Array([2, 4, 8], dtype=int32)
+
+    """  # noqa: E501
+
+    def __rlshift__(self, other: T) -> R:
+        return qnp.left_shift(other, self)
+
+
+# -------------------------------------
+
+
+class LaxBothLShiftMixin(LaxLShiftMixin[T, R], LaxRLShiftMixin[T, R]):
+    pass
+
+
+class NumpyBothLShiftMixin(NumpyLShiftMixin[T, R], NumpyRLShiftMixin[T, R]):
+    pass
+
+
+# ===============================================
+# Right Shift
+
+# -------------------------------------
+# `__rshift__`
+
+
+class LaxRShiftMixin(Generic[T, R]):
+    """Mixin for ``__rshift__`` method using quaxified `jax.lax.shift_right`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, LaxRShiftMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([2, 4, 8]))
+    >>> x >> 1
+    Array([1, 2, 4], dtype=int32)
+
+    """  # noqa: E501
+
+    _RIGHT_SHIFT_LOGICAL: Literal[True, False] = True
+
+    def __rshift__(self, other: T) -> R:
+        return qlax.cond(
+            self._RIGHT_SHIFT_LOGICAL,
+            qlax.shift_right_logical,
+            qlax.shift_right_arithmetic,
+            self,
+            other,
+        )
+
+
+class NumpyRShiftMixin(Generic[T, R]):
+    """Mixin for ``__rshift__`` method using quaxified `jax.numpy.rshift`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpyRShiftMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([2, 4, 8]))
+    >>> x >> 1
+    Array([1, 2, 4], dtype=int32)
+
+    """  # noqa: E501
+
+    def __rshift__(self, other: T) -> R:
+        return qnp.right_shift(self, other)
+
+
+# -------------------------------------
+# `__rrshift__`
+
+
+class LaxRRShiftMixin(Generic[T, R]):
+    """Mixin for ``__rrshift__`` method using quaxified `jax.lax.rshift`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, LaxRRShiftMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([2, 4, 8]))
+    >>> 16 >> x
+    Array([4, 1, 0], dtype=int32)
+
+    """  # noqa: E501
+
+    _RIGHT_SHIFT_LOGICAL: Literal[True, False] = True
+
+    def __rrshift__(self, other: T) -> R:
+        return qlax.cond(
+            self._RIGHT_SHIFT_LOGICAL,
+            qlax.shift_right_logical,
+            qlax.shift_right_arithmetic,
+            other,
+            self,
+        )
+
+
+class NumpyRRShiftMixin(Generic[T, R]):
+    """Mixin for ``__rrshift__`` method using quaxified `jax.numpy.rshift`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpyRRShiftMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([2, 4, 8]))
+    >>> 16 >> x
+    Array([4, 1, 0], dtype=int32)
+
+    """  # noqa: E501
+
+    def __rrshift__(self, other: T) -> R:
+        return qnp.right_shift(other, self)
+
+
+# -------------------------------------
+
+
+class LaxBothRShiftMixin(LaxRShiftMixin[T, R], LaxRRShiftMixin[T, R]):
+    pass
+
+
+class NumpyBothRShiftMixin(NumpyRShiftMixin[T, R], NumpyRRShiftMixin[T, R]):
+    pass
+
+
+# ===============================================
+# And
+
+# -------------------------------------
+# `__and__`
+
+
+class LaxAndMixin(Generic[T, R]):
+    """Mixin for ``__and__`` method using quaxified `jax.lax.and_`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, LaxAndMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> x & 1
+    Array([1, 0, 1], dtype=int32)
+
+    """  # noqa: E501
+
+    def __and__(self, other: T) -> R:
+        return qlax.bitwise_and(self, other)
+
+
+class NumpyAndMixin(Generic[T, R]):
+    """Mixin for ``__and__`` method using quaxified `jax.numpy.and_`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpyAndMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> x & 1
+    Array([1, 0, 1], dtype=int32)
+
+    """  # noqa: E501
+
+    def __and__(self, other: T) -> R:
+        return qnp.bitwise_and(self, other)
+
+
+# -------------------------------------
+# `__rand__`
+
+
+class LaxRAndMixin(Generic[T, R]):
+    """Mixin for ``__rand__`` method using quaxified `jax.lax.and_`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, LaxRAndMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> 1 & x
+    Array([1, 0, 1], dtype=int32)
+
+    """  # noqa: E501
+
+    def __rand__(self, other: T) -> R:
+        return qlax.bitwise_and(other, self)
+
+
+class NumpyRAndMixin(Generic[T, R]):
+    """Mixin for ``__rand__`` method using quaxified `jax.numpy.and_`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpyRAndMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> 1 & x
+    Array([1, 0, 1], dtype=int32)
+
+    """  # noqa: E501
+
+    def __rand__(self, other: T) -> R:
+        return qnp.bitwise_and(other, self)
+
+
+# -------------------------------------
+
+
+class LaxBothAndMixin(LaxAndMixin[T, R], LaxRAndMixin[T, R]):
+    pass
+
+
+class NumpyBothAndMixin(NumpyAndMixin[T, R], NumpyRAndMixin[T, R]):
+    pass
+
+
+# ===============================================
+# Xor
+
+
+# -------------------------------------
+# `__xor__`
+
+
+class LaxXorMixin(Generic[T, R]):
+    """Mixin for ``__xor__`` method using quaxified `jax.lax.xor`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, LaxXorMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> x ^ 1
+    Array([0, 3, 2], dtype=int32)
+
+    """  # noqa: E501
+
+    def __xor__(self, other: T) -> R:
+        return qlax.bitwise_xor(self, other)
+
+
+class NumpyXorMixin(Generic[T, R]):
+    """Mixin for ``__xor__`` method using quaxified `jax.numpy.xor`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpyXorMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> x ^ 1
+    Array([0, 3, 2], dtype=int32)
+
+    """  # noqa: E501
+
+    def __xor__(self, other: T) -> R:
+        return qnp.bitwise_xor(self, other)
+
+
+# -------------------------------------
+# `__rxor__`
+
+
+class LaxRXorMixin(Generic[T, R]):
+    """Mixin for ``__rxor__`` method using quaxified `jax.lax.xor`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, LaxRXorMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> 1 ^ x
+    Array([0, 3, 2], dtype=int32)
+
+    """  # noqa: E501
+
+    def __rxor__(self, other: T) -> R:
+        return qlax.bitwise_xor(other, self)
+
+
+class NumpyRXorMixin(Generic[T, R]):
+    """Mixin for ``__rxor__`` method using quaxified `jax.numpy.xor`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpyRXorMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> 1 ^ x
+    Array([0, 3, 2], dtype=int32)
+
+    """  # noqa: E501
+
+    def __rxor__(self, other: T) -> R:
+        return qnp.bitwise_xor(other, self)
+
+
+# -------------------------------------
+
+
+class LaxBothXorMixin(LaxXorMixin[T, R], LaxRXorMixin[T, R]):
+    pass
+
+
+class NumpyBothXorMixin(NumpyXorMixin[T, R], NumpyRXorMixin[T, R]):
+    pass
+
+
+# ================================================
+# Or
+
+# -------------------------------------
+# `__or__`
+
+
+class LaxOrMixin(Generic[T, R]):
+    """Mixin for ``__or__`` method using quaxified `jax.lax.or_`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, LaxOrMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> x | 1
+    Array([1, 3, 3], dtype=int32)
+
+    """  # noqa: E501
+
+    def __or__(self, other: T) -> R:
+        return qlax.bitwise_or(self, other)
+
+
+class NumpyOrMixin(Generic[T, R]):
+    """Mixin for ``__or__`` method using quaxified `jax.numpy.or_`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpyOrMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> x | 1
+    Array([1, 3, 3], dtype=int32)
+
+    """  # noqa: E501
+
+    def __or__(self, other: T) -> R:
+        return qnp.bitwise_or(self, other)
+
+
+# ================================================
+# Ror
+
+# -------------------------------------
+# `__ror__`
+
+
+class LaxROrMixin(Generic[T, R]):
+    """Mixin for ``__ror__`` method using quaxified `jax.lax.or_`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, LaxROrMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> 1 | x
+    Array([1, 3, 3], dtype=int32)
+
+    """  # noqa: E501
+
+    def __ror__(self, other: T) -> R:
+        return qlax.bitwise_or(other, self)
+
+
+class NumpyROrMixin(Generic[T, R]):
+    """Mixin for ``__ror__`` method using quaxified `jax.numpy.or_`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpyROrMixin[Any, Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> 1 | x
+    Array([1, 3, 3], dtype=int32)
+
+    """  # noqa: E501
+
+    def __ror__(self, other: T) -> R:
+        return qnp.bitwise_or(other, self)
+
+
+# -------------------------------------
+
+
+class LaxBothOrMixin(LaxOrMixin[T, R], LaxROrMixin[T, R]):
+    pass
+
+
+class NumpyBothOrMixin(NumpyOrMixin[T, R], NumpyROrMixin[T, R]):
+    pass
+
+
+# =================================================
+
+
+class LaxMathMixin(
+    LaxBothAddMixin[T, R],  # __add__, __radd__
+    LaxBothSubMixin[T, R],  # __sub__, __rsub__
+    LaxBothMulMixin[T, R],  # __mul__, __rmul__
+    LaxMatMulMixin[T, R],  # __matmul__
+    LaxBothTrueDivMixin[T, R],  # __truediv__, __rtruediv__
+    LaxBothFloorDivMixin[T, R],  # __floordiv__, __rfloordiv__
+    LaxBothModMixin[T, R],  # __mod__, __rmod__
+    # TODO: divmod
+    LaxBothPowMixin[T, R],  # __pow__, __rpow__
+):
+    pass
+
+
+class NumpyMathMixin(
+    NumpyBothAddMixin[T, R],  # __add__, __radd__
+    NumpyBothSubMixin[T, R],  # __sub__, __rsub__
+    NumpyBothMulMixin[T, R],  # __mul__, __rmul__
+    NumpyMatMulMixin[T, R],  # __matmul__
+    NumpyBothTrueDivMixin[T, R],  # __truediv__, __rtruediv__
+    NumpyBothFloorDivMixin[T, R],  # __floordiv__, __rfloordiv__
+    NumpyBothModMixin[T, R],  # __mod__, __rmod__
+    NumpyBothDivModMixin[T, R],  # __divmod__, __rdivmod__
+    NumpyBothPowMixin[T, R],  # __pow__, __rpow__
+):
+    pass
+
+
+class LaxBitwiseMixin(
+    LaxBothLShiftMixin[T, R],  # __lshift__, __rlshift__
+    LaxBothRShiftMixin[T, R],  # __rshift__, __rrshift__
+    LaxBothAndMixin[T, R],  # __and__, __rand__
+    LaxBothXorMixin[T, R],  # __xor__, __rxor__
+    LaxBothOrMixin[T, R],  # __or__, __ror__
+):
+    pass
+
+
+class NumpyBitwiseMixin(
+    NumpyBothLShiftMixin[T, R],  # __lshift__, __rlshift__
+    NumpyBothRShiftMixin[T, R],  # __rshift__, __rrshift__
+    NumpyBothAndMixin[T, R],  # __and__, __rand__
+    NumpyBothXorMixin[T, R],  # __xor__, __rxor__
+    NumpyBothOrMixin[T, R],  # __or__, __ror__
+):
+    pass
+
+
+# =================================================
+
+
+class LaxBinaryOpsMixin(LaxMathMixin[T, R], LaxBitwiseMixin[T, R]):
+    pass
+
+
+class NumpyBinaryOpsMixin(NumpyMathMixin[T, R], NumpyBitwiseMixin[T, R]):
+    pass

--- a/src/quaxed/experimental/_arrayish/container.py
+++ b/src/quaxed/experimental/_arrayish/container.py
@@ -1,0 +1,130 @@
+"""Container operations for Array-ish objects."""
+
+# fmt: off
+__all__ = [
+    "LaxLenMixin", "NumpyLenMixin",  # __len__
+    "LaxLengthHintMixin", "NumpyLengthHintMixin",  # __length_hint__
+]
+# fmt: on
+
+from typing import Protocol, TypeVar, runtime_checkable
+
+import quaxed.numpy as qnp
+
+T = TypeVar("T")
+
+
+@runtime_checkable
+class HasShape(Protocol):
+    @property
+    def shape(self) -> tuple[int, ...]:
+        """Return the shape of the object."""
+        ...
+
+
+# -----------------------------------------------
+# `__len__`
+
+
+class LaxLenMixin:
+    """Mixin for ``__len__`` method using quaxified `jax.lax.len`.
+
+    Examples
+    --------
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, LaxLenMixin):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> len(x)
+    3
+
+    """  # noqa: E501
+
+    def __len__(self: HasShape) -> int:
+        return self.shape[0]
+
+
+class NumpyLenMixin:
+    """Mixin for ``__len__`` method using quaxified `jax.numpy.len`.
+
+    Examples
+    --------
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpyLenMixin):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> len(x)
+    3
+
+    """  # noqa: E501
+
+    def __len__(self) -> int:
+        return qnp.shape(self)[0]
+
+
+# -----------------------------------------------
+# `__length_hint__`
+
+
+class LaxLengthHintMixin:
+    """Mixin for ``__length_hint__`` method using quaxified `jax.lax.length_hint`.
+
+    Examples
+    --------
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, LaxLengthHintMixin):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> x.__length_hint__()
+    3
+
+    """  # noqa: E501
+
+    def __length_hint__(self: HasShape) -> int:
+        return self.shape[0]
+
+
+class NumpyLengthHintMixin:
+    """Mixin for ``__length_hint__`` method using quaxified `jax.numpy.length_hint`.
+
+    Examples
+    --------
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpyLengthHintMixin):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> x.__length_hint__()
+    3
+
+    """  # noqa: E501
+
+    def __length_hint__(self) -> int:
+        return qnp.shape(self)[0]

--- a/src/quaxed/experimental/_arrayish/copy.py
+++ b/src/quaxed/experimental/_arrayish/copy.py
@@ -1,0 +1,75 @@
+"""Copy operations for Array-ish objects."""
+
+__all__ = [
+    "NumpyCopyMixin",  # __copy__
+    "NumpyDeepCopyMixin",  # __deepcopy__
+]
+
+from typing import Any, Generic
+from typing_extensions import TypeVar
+
+import optype as opt
+
+import quaxed.numpy as qnp
+
+RCopy = TypeVar("RCopy", default=opt.copy.CanCopySelf)
+RDeepcopy = TypeVar("RDeepcopy", default=opt.copy.CanDeepcopySelf)
+
+# -----------------------------------------------
+# `__copy__`
+
+
+class NumpyCopyMixin(Generic[RCopy]):
+    """Mixin for ``__copy__`` method using quaxified `jax.numpy.copy`.
+
+    Examples
+    --------
+    >>> import copy
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpyCopyMixin[Any]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> copy.copy(x)
+    Array([1, 2, 3], dtype=int32)
+
+    """  # noqa: E501
+
+    def __copy__(self) -> RCopy:
+        return qnp.copy(self)
+
+
+# -----------------------------------------------
+# `__deepcopy__`
+
+
+class NumpyDeepCopyMixin(Generic[RDeepcopy]):
+    """Mixin for ``__deepcopy__`` method using quaxified `jax.numpy.copy`.
+
+    Examples
+    --------
+    >>> import copy
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpyDeepCopyMixin[Any]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> copy.deepcopy(x)
+    Array([1, 2, 3], dtype=int32)
+
+    """  # noqa: E501
+
+    def __deepcopy__(self, memo: dict[Any, Any], /) -> RDeepcopy:
+        return qnp.copy(self)

--- a/src/quaxed/experimental/_arrayish/rich.py
+++ b/src/quaxed/experimental/_arrayish/rich.py
@@ -1,0 +1,412 @@
+"""Rich operations for Array-ish objects."""
+
+# fmt: off
+__all__ = [
+    "LaxComparisonMixin", "NumpyComparisonMixin",  # rich comparison
+    # ----------
+    "LaxEqMixin", "NumpyEqMixin",  # `__eq__`
+    "LaxNeMixin", "NumpyNeMixin",  # `__ne__`
+    "LaxLtMixin", "NumpyLtMixin",  # `__lt__`
+    "LaxLeMixin", "NumpyLeMixin",  # `__le__`
+    "LaxGtMixin", "NumpyGtMixin",  # `__gt__`
+    "LaxGeMixin", "NumpyGeMixin",  # `__ge__`
+]
+# fmt: on
+
+
+from typing import Generic
+from typing_extensions import TypeVar, override
+
+import quaxed.lax as qlax
+import quaxed.numpy as qnp
+
+T = TypeVar("T")
+Rbool = TypeVar("Rbool", default=bool)
+
+# -----------------------------------------------
+# `__eq__`
+
+
+class LaxEqMixin(Generic[T, Rbool]):
+    """Mixin for ``__eq__`` method using quaxified `jax.lax.eq`.
+
+    !!! warning
+        Equinox PyTree provides an `__eq__` method that cannot be overridden by
+        subclassing in this way. To ensure correct behavior, you need to
+        explicitly assign the `__eq__` method in your subclass.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array, Bool
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, LaxEqMixin[Any, Bool[Array, "..."]]):
+    ...     value: Array
+    ...     __eq__ = LaxEqMixin.__eq__
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> x == x
+    Array([ True,  True,  True], dtype=bool)
+
+    >>> x == 1
+    Array([ True, False, False], dtype=bool)
+
+    """  # noqa: E501
+
+    @override
+    def __eq__(self, other: T) -> Rbool:  # type: ignore[override]
+        return qlax.eq(self, other)
+
+
+class NumpyEqMixin(Generic[T, Rbool]):
+    """Mixin for ``__eq__`` method using quaxified `jax.numpy.eq`.
+
+    !!! warning
+        Equinox PyTree provides an `__eq__` method that cannot be overridden by
+        subclassing in this way. To ensure correct behavior, you need to
+        explicitly assign the `__eq__` method in your subclass.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array, Bool
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpyEqMixin[Any, Bool[Array, "..."]]):
+    ...     value: Array
+    ...     __eq__ = NumpyEqMixin.__eq__
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> x == x
+    Array([ True,  True,  True], dtype=bool)
+
+    >>> x == 1
+    Array([ True, False, False], dtype=bool)
+
+    """  # noqa: E501
+
+    @override
+    def __eq__(self, other: T) -> Rbool:  # type: ignore[override]
+        return qnp.equal(self, other)
+
+
+# -----------------------------------------------
+# `__ne__`
+
+
+class LaxNeMixin(Generic[T, Rbool]):
+    """Mixin for ``__ne__`` method using quaxified `jax.lax.ne`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array, Bool
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, LaxNeMixin[Any, Bool[Array, "..."]]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> x != x
+    Array([False, False, False], dtype=bool)
+
+    >>> x != 1
+    Array([False,  True,  True], dtype=bool)
+
+    """  # noqa: E501
+
+    @override
+    def __ne__(self, other: T) -> Rbool:  # type: ignore[override]
+        return qlax.ne(self, other)
+
+
+class NumpyNeMixin(Generic[T, Rbool]):
+    """Mixin for ``__ne__`` method using quaxified `jax.numpy.ne`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array, Bool
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpyNeMixin[Any, Bool[Array, "..."]]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> x != x
+    Array([False, False, False], dtype=bool)
+
+    >>> x != 1
+    Array([False,  True,  True], dtype=bool)
+
+    """  # noqa: E501
+
+    @override
+    def __ne__(self, other: T) -> Rbool:  # type: ignore[override]
+        return qnp.not_equal(self, other)
+
+
+# -----------------------------------------------
+# `__lt__`
+
+
+class LaxLtMixin(Generic[T, Rbool]):
+    """Mixin for ``__lt__`` method using quaxified `jax.lax.lt`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array, Bool
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, LaxLtMixin[Any, Bool[Array, "..."]]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> x < 2
+    Array([ True, False, False], dtype=bool)
+
+    """  # noqa: E501
+
+    def __lt__(self, other: T) -> Rbool:
+        return qlax.lt(self, other)
+
+
+class NumpyLtMixin(Generic[T, Rbool]):
+    """Mixin for ``__lt__`` method using quaxified `jax.numpy.lt`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array, Bool
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpyLtMixin[Any, Bool[Array, "..."]]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> x < 2
+    Array([ True, False, False], dtype=bool)
+
+    """  # noqa: E501
+
+    def __lt__(self, other: T) -> Rbool:
+        return qnp.less(self, other)
+
+
+# -----------------------------------------------
+# `__le__`
+
+
+class LaxLeMixin(Generic[T, Rbool]):
+    """Mixin for ``__le__`` method using quaxified `jax.lax.le`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array, Bool
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, LaxLeMixin[Any, Bool[Array, "..."]]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> x <= 2
+    Array([ True,  True, False], dtype=bool)
+
+    """  # noqa: E501
+
+    def __le__(self, other: T) -> Rbool:
+        return qlax.le(self, other)
+
+
+class NumpyLeMixin(Generic[T, Rbool]):
+    """Mixin for ``__le__`` method using quaxified `jax.numpy.le`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array, Bool
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpyLeMixin[Any, Bool[Array, "..."]]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> x <= 2
+    Array([ True,  True, False], dtype=bool)
+
+    """  # noqa: E501
+
+    def __le__(self, other: T) -> Rbool:
+        return qnp.less_equal(self, other)
+
+
+# -----------------------------------------------
+# `__gt__`
+
+
+class LaxGtMixin(Generic[T, Rbool]):
+    """Mixin for ``__gt__`` method using quaxified `jax.lax.gt`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array, Bool
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, LaxGtMixin[Any, Bool[Array, "..."]]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> x > 2
+    Array([False, False,  True], dtype=bool)
+
+    """  # noqa: E501
+
+    def __gt__(self, other: T) -> Rbool:
+        return qlax.gt(self, other)
+
+
+class NumpyGtMixin(Generic[T, Rbool]):
+    """Mixin for ``__gt__`` method using quaxified `jax.numpy.gt`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array, Bool
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpyGtMixin[Any, Bool[Array, "..."]]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> x > 2
+    Array([False, False,  True], dtype=bool)
+
+    """  # noqa: E501
+
+    def __gt__(self, other: T) -> Rbool:
+        return qnp.greater(self, other)
+
+
+# -----------------------------------------------
+# `__ge__`
+
+
+class LaxGeMixin(Generic[T, Rbool]):
+    """Mixin for ``__ge__`` method using quaxified `jax.lax.ge`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array, Bool
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, LaxGeMixin[Any, Bool[Array, "..."]]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> x >= 2
+    Array([False,  True,  True], dtype=bool)
+
+    """  # noqa: E501
+
+    def __ge__(self, other: T) -> Rbool:
+        return qlax.ge(self, other)
+
+
+class NumpyGeMixin(Generic[T, Rbool]):
+    """Mixin for ``__ge__`` method using quaxified `jax.numpy.ge`.
+
+    Examples
+    --------
+    >>> from typing import Any
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array, Bool
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpyGeMixin[Any, Bool[Array, "..."]]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> x >= 2
+    Array([False,  True,  True], dtype=bool)
+
+    """  # noqa: E501
+
+    def __ge__(self, other: T) -> Rbool:
+        return qnp.greater_equal(self, other)
+
+
+# ================================================
+
+
+class LaxComparisonMixin(
+    LaxEqMixin[T, Rbool],
+    LaxNeMixin[T, Rbool],
+    LaxLtMixin[T, Rbool],
+    LaxLeMixin[T, Rbool],
+    LaxGtMixin[T, Rbool],
+    LaxGeMixin[T, Rbool],
+):
+    pass
+
+
+class NumpyComparisonMixin(
+    NumpyEqMixin[T, Rbool],
+    NumpyNeMixin[T, Rbool],
+    NumpyLtMixin[T, Rbool],
+    NumpyLeMixin[T, Rbool],
+    NumpyGtMixin[T, Rbool],
+    NumpyGeMixin[T, Rbool],
+):
+    pass

--- a/src/quaxed/experimental/_arrayish/round.py
+++ b/src/quaxed/experimental/_arrayish/round.py
@@ -1,0 +1,254 @@
+"""Rounding operations for Array-ish objects."""
+
+# fmt: off
+__all__ = [
+    "LaxRoundMixin", "NumpyRoundMixin",  # __round__
+    "LaxTruncMixin", "NumpyTruncMixin",  # __trunc__
+    "LaxFloorMixin", "NumpyFloorMixin",  # __floor__
+    "LaxCeilMixin", "NumpyCeilMixin",  # __ceil__
+]
+# fmt: on
+
+from functools import partial
+from typing import Generic, Literal
+from typing_extensions import TypeVar
+
+import jax
+from jaxtyping import Array, Bool, PyTree, Shaped
+
+import quaxed.lax as qlax
+import quaxed.numpy as qnp
+
+from .rich import LaxGeMixin
+
+T = TypeVar("T")
+R = TypeVar("R", default=bool)
+
+# -----------------------------------------------
+# `__round__`
+
+
+class LaxRoundMixin(Generic[R]):
+    """Mixin for ``__round__`` method using quaxified `jax.lax.round`.
+
+    Examples
+    --------
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, LaxRoundMixin[Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1.2, 2.5, 3.7]))
+    >>> round(x)
+    Array([1., 3., 4.], dtype=float32)
+
+    """  # noqa: E501
+
+    _ROUNDING_METHOD: Literal[qlax.RoundingMethod] = qlax.RoundingMethod.AWAY_FROM_ZERO  # type: ignore[valid-type]
+
+    def __round__(self) -> R:
+        return qlax.round(self, self._ROUNDING_METHOD)
+
+
+class NumpyRoundMixin(Generic[R]):
+    """Mixin for ``__round__`` method using quaxified `jax.numpy.round`.
+
+    Examples
+    --------
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpyRoundMixin[Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1.2, 2.5, 3.7]))
+    >>> round(x)
+    Array([1., 2., 4.], dtype=float32)
+
+    """  # noqa: E501
+
+    @partial(jax.jit, static_argnums=1)
+    def __round__(self, ndigits: int = 0) -> R:
+        return qnp.round(self, decimals=ndigits)
+
+
+# -----------------------------------------------
+# `__trunc__`
+
+
+class LaxTruncMixin(
+    LaxGeMixin[PyTree[Shaped[Array, "..."]], Bool[Array, "..."]], Generic[R]
+):
+    """Mixin for ``__trunc__`` method using quaxified `jax.lax.floor`, `jax.lax.ceil`.
+
+    Uses quaxified `jax.lax.select` to apply `qlax.floor` for positive values
+    and `qlax.ceil` for negative values.
+
+    Examples
+    --------
+    >>> import math
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, LaxTruncMixin[Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1.2, 2.5, 3.7, -1.2, -2.5, -3.7]))
+    >>> math.trunc(x)
+    Array([ 1.,  2.,  3., -1., -2., -3.], dtype=float32)
+
+    """  # noqa: E501
+
+    def __trunc__(self) -> R:
+        return qlax.select(
+            qlax.ge(self, qlax.full_like(self, 0)),
+            qlax.floor(self),
+            qlax.ceil(self),
+        )
+
+
+class NumpyTruncMixin(Generic[R]):
+    """Mixin for ``__trunc__`` method using quaxified `jax.numpy.trunc`.
+
+    Examples
+    --------
+    >>> import math
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpyTruncMixin[Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1.2, 2.5, 3.7]))
+    >>> math.trunc(x)
+    Array([1., 2., 3.], dtype=float32)
+
+    """  # noqa: E501
+
+    def __trunc__(self) -> R:
+        return qnp.trunc(self)
+
+
+# -----------------------------------------------
+# `__floor__`
+
+
+class LaxFloorMixin(Generic[R]):
+    """Mixin for ``__floor__`` method using quaxified `jax.lax.floor`.
+
+    Examples
+    --------
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, LaxFloorMixin[Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1.2, 2.5, 3.7]))
+    >>> x.__floor__()
+    Array([1., 2., 3.], dtype=float32)
+
+    """  # noqa: E501
+
+    def __floor__(self) -> R:
+        return qlax.floor(self)
+
+
+class NumpyFloorMixin(Generic[R]):
+    """Mixin for ``__floor__`` method using quaxified `jax.numpy.floor`.
+
+    Examples
+    --------
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpyFloorMixin[Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1.2, 2.5, 3.7]))
+    >>> x.__floor__()
+    Array([1., 2., 3.], dtype=float32)
+
+    """  # noqa: E501
+
+    def __floor__(self) -> R:
+        return qnp.floor(self)
+
+
+# -----------------------------------------------
+# `__ceil__`
+
+
+class LaxCeilMixin(Generic[R]):
+    """Mixin for ``__ceil__`` method using quaxified `jax.lax.ceil`.
+
+    Examples
+    --------
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, LaxCeilMixin[Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1.2, 2.5, 3.7]))
+    >>> x.__ceil__()
+    Array([2., 3., 4.], dtype=float32)
+
+    """  # noqa: E501
+
+    def __ceil__(self) -> R:
+        return qlax.ceil(self)
+
+
+class NumpyCeilMixin(Generic[R]):
+    """Mixin for ``__ceil__`` method using quaxified `jax.numpy.ceil`.
+
+    Examples
+    --------
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpyCeilMixin[Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1.2, 2.5, 3.7]))
+    >>> x.__ceil__()
+    Array([2., 3., 4.], dtype=float32)
+
+    """  # noqa: E501
+
+    def __ceil__(self) -> R:
+        return qnp.ceil(self)

--- a/src/quaxed/experimental/_arrayish/unary.py
+++ b/src/quaxed/experimental/_arrayish/unary.py
@@ -1,0 +1,228 @@
+"""Unary operations for array-ish objects."""
+
+# fmt: off
+__all__ = [
+    "LaxUnaryMixin", "NumpyUnaryMixin",
+    # ----------
+    "LaxPosMixin", "NumpyPosMixin",  # __pos__
+    "LaxNegMixin", "NumpyNegMixin",  # __neg__
+    "NumpyInvertMixin",              # __invert__
+    "LaxAbsMixin", "NumpyAbsMixin",  # __abs__
+]
+# fmt: on
+
+from typing import Generic
+from typing_extensions import TypeVar
+
+import optype as opt
+
+import quaxed.lax as qlax
+import quaxed.numpy as qnp
+
+T = TypeVar("T")
+R = TypeVar("R", default=bool)
+
+# -----------------------------------------------
+# `__pos__`
+
+
+class LaxPosMixin:
+    """Mixin for ``__pos__`` method using quaxified `jax.lax.pos`.
+
+    Examples
+    --------
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, LaxPosMixin):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> +x
+    MyArray(value=i32[3])
+
+    """  # noqa: E501
+
+    def __pos__(self: opt.CanPosSelf) -> opt.CanPosSelf:
+        return self  # TODO: more robust implementation
+
+
+class NumpyPosMixin:
+    """Mixin for ``__pos__`` method using quaxified `jax.numpy.pos`.
+
+    Examples
+    --------
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpyPosMixin):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> +x
+    MyArray(value=i32[3])
+
+    """  # noqa: E501
+
+    def __pos__(self) -> opt.CanPosSelf:
+        return qnp.positive(self)
+
+
+# -----------------------------------------------
+# `__neg__`
+
+
+class LaxNegMixin(Generic[R]):
+    """Mixin for ``__neg__`` method using quaxified `jax.lax.neg`.
+
+    Examples
+    --------
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, LaxNegMixin[Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> -x
+    Array([-1, -2, -3], dtype=int32)
+
+    """  # noqa: E501
+
+    def __neg__(self) -> R:
+        return qlax.neg(self)
+
+
+class NumpyNegMixin(Generic[R]):
+    """Mixin for ``__neg__`` method using quaxified `jax.numpy.neg`.
+
+    Examples
+    --------
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpyNegMixin[Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> -x
+    Array([-1, -2, -3], dtype=int32)
+
+    """  # noqa: E501
+
+    def __neg__(self) -> R:
+        return qnp.negative(self)
+
+
+# -----------------------------------------------
+# `__invert__`
+
+
+# TODO: LaxInvertMixin for jax.lax.invert does not exist yet
+
+
+class NumpyInvertMixin(Generic[R]):
+    """Mixin for ``__invert__`` method using quaxified `jax.numpy.invert`.
+
+    Examples
+    --------
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpyInvertMixin[Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([1, 2, 3]))
+    >>> ~x
+    Array([-2, -3, -4], dtype=int32)
+
+    """  # noqa: E501
+
+    def __invert__(self) -> R:
+        return qnp.invert(self)
+
+
+# -----------------------------------------------
+# `__abs__`
+
+
+class LaxAbsMixin(Generic[R]):
+    """Mixin for ``__abs__`` method using quaxified `jax.lax.abs`.
+
+    Examples
+    --------
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, LaxAbsMixin[Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([-1, -2, -3]))
+    >>> abs(x)
+    Array([1, 2, 3], dtype=int32)
+
+    """  # noqa: E501
+
+    def __abs__(self) -> R:
+        return qlax.abs(self)
+
+
+class NumpyAbsMixin(Generic[R]):
+    """Mixin for ``__abs__`` method using quaxified `jax.numpy.abs`.
+
+    Examples
+    --------
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from jaxtyping import Array
+    >>> from quax import ArrayValue
+
+    >>> class MyArray(ArrayValue, NumpyAbsMixin[Array]):
+    ...     value: Array
+    ...     def aval(self): return jax.core.ShapedArray(self.value.shape, self.value.dtype)
+    ...     def materialise(self): return self.value
+
+    >>> x = MyArray(jnp.array([-1, -2, -3]))
+    >>> abs(x)
+    Array([1, 2, 3], dtype=int32)
+
+    """  # noqa: E501
+
+    def __abs__(self) -> R:
+        return qnp.abs(self)
+
+
+# ===============================================
+# Combined Mixins
+
+
+class LaxUnaryMixin(LaxPosMixin, LaxNegMixin, LaxAbsMixin):
+    """Combined mixin for unary operations using quaxified `jax.lax`."""
+
+
+class NumpyUnaryMixin(NumpyPosMixin, NumpyNegMixin, NumpyAbsMixin, NumpyInvertMixin):
+    """Combined mixin for unary operations using quaxified `jax.numpy`."""

--- a/src/quaxed/experimental/arrayish.py
+++ b/src/quaxed/experimental/arrayish.py
@@ -1,4 +1,9 @@
-"""Building blocks for Array-ish objects."""
+"""Building blocks for Array-ish objects.
+
+!!! warning "Experimental"
+    This module is experimental and subject to change. Use with caution.
+
+"""
 
 # fmt: off
 __all__ = [

--- a/src/quaxed/experimental/arrayish.py
+++ b/src/quaxed/experimental/arrayish.py
@@ -1,0 +1,229 @@
+"""Building blocks for Array-ish objects."""
+
+# fmt: off
+__all__ = [
+    ################################################
+    "LaxComparisonMixin", "NumpyComparisonMixin",  # rich comparison
+    # ----------
+    "LaxEqMixin", "NumpyEqMixin",  # `__eq__`
+    "LaxNeMixin", "NumpyNeMixin",  # `__ne__`
+    "LaxLtMixin", "NumpyLtMixin",  # `__lt__`
+    "LaxLeMixin", "NumpyLeMixin",  # `__le__`
+    "LaxGtMixin", "NumpyGtMixin",  # `__gt__`
+    "LaxGeMixin", "NumpyGeMixin",  # `__ge__`
+    ##################################################
+    "LaxBinaryOpsMixin", "NumpyBinaryOpsMixin",
+    # ========== Float Operations ==========
+    "LaxMathMixin", "NumpyMathMixin",
+    # ----- add -----
+    "LaxBothAddMixin", "NumpyBothAddMixin",
+    "LaxAddMixin", "NumpyAddMixin",  # __add__
+    "LaxRAddMixin", "NumpyRAddMixin",  # __radd__
+    # ----- sub -----
+    "LaxBothSubMixin", "NumpyBothSubMixin",
+    "LaxSubMixin", "NumpySubMixin",  # __sub__
+    "LaxRSubMixin", "NumpyRSubMixin",  # __rsub__
+    # ----- mul -----
+    "LaxBothMulMixin", "NumpyBothMulMixin",
+    "LaxMulMixin", "NumpyMulMixin",  # __mul__
+    "LaxRMulMixin", "NumpyRMulMixin",  # __rmul__
+    # ---- matmul -----
+    "LaxMatMulMixin", "NumpyMatMulMixin",  # __matmul__
+    # "LaxRMatMulMixin", "NumpyRMatMulMixin",  # __rmatmul__
+    # ----- truediv -----
+    "LaxBothTrueDivMixin", "NumpyBothTrueDivMixin",
+    "LaxTrueDivMixin", "NumpyTrueDivMixin",  # __truediv__
+    "LaxRTrueDivMixin", "NumpyRTrueDivMixin",  # __rtruediv__
+    # ----- floordiv -----
+    "LaxBothFloorDivMixin", "NumpyBothFloorDivMixin",
+    "LaxFloorDivMixin", "NumpyFloorDivMixin",  # __floordiv__
+    "LaxRFloorDivMixin", "NumpyRFloorDivMixin",  # __rfloordiv__
+    # ----- mod -----
+    "LaxBothModMixin", "NumpyBothModMixin",
+    "LaxModMixin", "NumpyModMixin",  # __mod__
+    "LaxRModMixin", "NumpyRModMixin",  # __rmod__
+    # ----- divmod -----
+    "NumpyBothDivModMixin",
+    # "LaxDivModMixin",
+    "NumpyDivModMixin",
+    # "LaxRDivModMixin",
+    "NumpyRDivModMixin",
+    # ----- pow -----
+    "LaxBothPowMixin", "NumpyBothPowMixin",
+    "LaxPowMixin", "NumpyPowMixin",  # __pow__
+    "LaxRPowMixin", "NumpyRPowMixin",  # __rpow__
+    # ========== Bitwise Operations ==========
+    "LaxBitwiseMixin", "NumpyBitwiseMixin",
+    # ----- lshift -----
+    "LaxBothLShiftMixin", "NumpyBothLShiftMixin",
+    "LaxLShiftMixin", "NumpyLShiftMixin",  # __lshift__
+    "LaxRLShiftMixin", "NumpyRLShiftMixin",  # __rlshift__
+    # ----- rshift -----
+    "LaxBothRShiftMixin", "NumpyBothRShiftMixin",
+    "LaxRShiftMixin", "NumpyRShiftMixin",  # __rshift__
+    "LaxRRShiftMixin", "NumpyRRShiftMixin",  # __rrshift__
+    # ----- and -----
+    "LaxBothAndMixin", "NumpyBothAndMixin",
+    "LaxAndMixin", "NumpyAndMixin",  # __and__
+    "LaxRAndMixin", "NumpyRAndMixin",  # __rand__
+    # ----- xor -----
+    "LaxBothXorMixin", "NumpyBothXorMixin",
+    "LaxXorMixin", "NumpyXorMixin",  # __xor__
+    "LaxRXorMixin", "NumpyRXorMixin",  # __rxor__
+    # ----- or -----
+    "LaxBothOrMixin", "NumpyBothOrMixin",
+    "LaxOrMixin", "NumpyOrMixin",  # __or__
+    "LaxROrMixin", "NumpyROrMixin",  # __ror__
+    ##################################################
+    "LaxUnaryMixin", "NumpyUnaryMixin",
+    # ----------
+    "LaxPosMixin", "NumpyPosMixin",  # __pos__
+    "LaxNegMixin", "NumpyNegMixin",  # __neg__
+    "NumpyInvertMixin",              # __invert__
+    "LaxAbsMixin", "NumpyAbsMixin",  # __abs__
+    #################################################
+    "LaxRoundMixin", "NumpyRoundMixin",  # __round__
+    "LaxTruncMixin", "NumpyTruncMixin",  # __trunc__
+    "LaxFloorMixin", "NumpyFloorMixin",  # __floor__
+    "LaxCeilMixin", "NumpyCeilMixin",  # __ceil__
+    ##################################################
+    "LaxLenMixin", "NumpyLenMixin",  # __len__
+    "LaxLengthHintMixin", "NumpyLengthHintMixin",  # __length_hint__
+    #################################################
+    "NumpyCopyMixin",  # __copy__
+    "NumpyDeepCopyMixin",  # __deepcopy__
+]
+# fmt: on
+
+from ._arrayish.binary import (
+    LaxAddMixin,
+    LaxAndMixin,
+    LaxBinaryOpsMixin,
+    LaxBitwiseMixin,
+    LaxBothAddMixin,
+    LaxBothAndMixin,
+    LaxBothFloorDivMixin,
+    LaxBothLShiftMixin,
+    LaxBothModMixin,
+    LaxBothMulMixin,
+    LaxBothOrMixin,
+    LaxBothPowMixin,
+    LaxBothRShiftMixin,
+    LaxBothSubMixin,
+    LaxBothTrueDivMixin,
+    LaxBothXorMixin,
+    LaxFloorDivMixin,
+    LaxLShiftMixin,
+    LaxMathMixin,
+    LaxMatMulMixin,
+    LaxModMixin,
+    LaxMulMixin,
+    LaxOrMixin,
+    LaxPowMixin,
+    LaxRAddMixin,
+    LaxRAndMixin,
+    LaxRFloorDivMixin,
+    LaxRLShiftMixin,
+    LaxRModMixin,
+    LaxRMulMixin,
+    LaxROrMixin,
+    LaxRPowMixin,
+    LaxRRShiftMixin,
+    LaxRShiftMixin,
+    LaxRSubMixin,
+    LaxRTrueDivMixin,
+    LaxRXorMixin,
+    LaxSubMixin,
+    LaxTrueDivMixin,
+    LaxXorMixin,
+    NumpyAddMixin,
+    NumpyAndMixin,
+    NumpyBinaryOpsMixin,
+    NumpyBitwiseMixin,
+    NumpyBothAddMixin,
+    NumpyBothAndMixin,
+    NumpyBothDivModMixin,
+    NumpyBothFloorDivMixin,
+    NumpyBothLShiftMixin,
+    NumpyBothModMixin,
+    NumpyBothMulMixin,
+    NumpyBothOrMixin,
+    NumpyBothPowMixin,
+    NumpyBothRShiftMixin,
+    NumpyBothSubMixin,
+    NumpyBothTrueDivMixin,
+    NumpyBothXorMixin,
+    NumpyDivModMixin,
+    NumpyFloorDivMixin,
+    NumpyLShiftMixin,
+    NumpyMathMixin,
+    NumpyMatMulMixin,
+    NumpyModMixin,
+    NumpyMulMixin,
+    NumpyOrMixin,
+    NumpyPowMixin,
+    NumpyRAddMixin,
+    NumpyRAndMixin,
+    NumpyRDivModMixin,
+    NumpyRFloorDivMixin,
+    NumpyRLShiftMixin,
+    NumpyRModMixin,
+    NumpyRMulMixin,
+    NumpyROrMixin,
+    NumpyRPowMixin,
+    NumpyRRShiftMixin,
+    NumpyRShiftMixin,
+    NumpyRSubMixin,
+    NumpyRTrueDivMixin,
+    NumpyRXorMixin,
+    NumpySubMixin,
+    NumpyTrueDivMixin,
+    NumpyXorMixin,
+)
+from ._arrayish.container import (
+    LaxLengthHintMixin,
+    LaxLenMixin,
+    NumpyLengthHintMixin,
+    NumpyLenMixin,
+)
+from ._arrayish.copy import (
+    NumpyCopyMixin,
+    NumpyDeepCopyMixin,
+)
+from ._arrayish.rich import (
+    LaxComparisonMixin,
+    LaxEqMixin,
+    LaxGeMixin,
+    LaxGtMixin,
+    LaxLeMixin,
+    LaxLtMixin,
+    LaxNeMixin,
+    NumpyComparisonMixin,
+    NumpyEqMixin,
+    NumpyGeMixin,
+    NumpyGtMixin,
+    NumpyLeMixin,
+    NumpyLtMixin,
+    NumpyNeMixin,
+)
+from ._arrayish.round import (
+    LaxCeilMixin,
+    LaxFloorMixin,
+    LaxRoundMixin,
+    LaxTruncMixin,
+    NumpyCeilMixin,
+    NumpyFloorMixin,
+    NumpyRoundMixin,
+    NumpyTruncMixin,
+)
+from ._arrayish.unary import (
+    LaxAbsMixin,
+    LaxNegMixin,
+    LaxPosMixin,
+    LaxUnaryMixin,
+    NumpyAbsMixin,
+    NumpyInvertMixin,
+    NumpyNegMixin,
+    NumpyPosMixin,
+    NumpyUnaryMixin,
+)

--- a/uv.lock
+++ b/uv.lock
@@ -911,6 +911,18 @@ wheels = [
 ]
 
 [[package]]
+name = "optype"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/42/543e02c72aba7ebe78adb76bbfbed1bc1314eba633ad453984948e5a5f46/optype-0.8.0.tar.gz", hash = "sha256:8cbfd452d6f06c7c70502048f38a0d5451bc601054d3a577dd09c7d6363950e1", size = 85295 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/ff/604be975eb0e9fd02358cdacf496f4411db97bffc27279ce260e8f50aba4/optype-0.8.0-py3-none-any.whl", hash = "sha256:90a7760177f2e7feae379a60445fceec37b932b75a00c3d96067497573c5e84d", size = 74228 },
+]
+
+[[package]]
 name = "packaging"
 version = "24.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1230,12 +1242,13 @@ wheels = [
 
 [[package]]
 name = "quaxed"
-version = "0.7.2.dev3+g92326ee.d20250120"
+version = "0.7.2.dev4+g7d8f599.d20250120"
 source = { editable = "." }
 dependencies = [
     { name = "jax" },
     { name = "jaxlib" },
     { name = "jaxtyping" },
+    { name = "optype" },
     { name = "plum-dispatch" },
     { name = "quax" },
 ]
@@ -1284,6 +1297,7 @@ requires-dist = [
     { name = "jax", specifier = ">=0.4.3" },
     { name = "jaxlib", specifier = ">=0.4.3" },
     { name = "jaxtyping", specifier = ">=0.2.34" },
+    { name = "optype", specifier = ">=0.8.0" },
     { name = "plum-dispatch", specifier = ">=2.5.2" },
     { name = "quax", specifier = ">=0.0.5" },
 ]


### PR DESCRIPTION
This is a comprehensive set of classes which provide quaxified lax and jax.numpy-backed dunder methods.
This will be useful for `unxt.Quantity`, `coordinax.AbstractVector`, ....