### PR TITLE
⬆️ deps: require quax>=0.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
   "optype>=0.8.0",
   'plum-dispatch>=2.5.7; python_version < "3.14"',
   'plum-dispatch>=2.9.0; python_version >= "3.14"',
-  "quax>=0.4.0",
+  "quax>=0.4.1",
 ]
 description = "Pre-quaxed libraries for multiple dispatch over abstract array types in JAX"
 dynamic = ["version"]
@@ -45,7 +45,7 @@ quaxed-make-stubs = "quaxed._tools.make_stubs:main"
 
 [build-system]
 build-backend = "hatchling.build"
-requires      = ["hatchling", "hatch-vcs", "jax>=0.7.2", "quax>=0.4.0"]
+requires      = ["hatchling", "hatch-vcs", "jax>=0.7.2", "quax>=0.4.1"]
 
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,8 @@ dependencies = [
   "optype>=0.8.0",
   'plum-dispatch>=2.5.7; python_version < "3.14"',
   'plum-dispatch>=2.9.0; python_version >= "3.14"',
-  "quax>=0.3.2",
+  'quax>=0.3.2; python_version < "3.14"',
+  'quax>=0.4.0; python_version >= "3.14"',
 ]
 description = "Pre-quaxed libraries for multiple dispatch over abstract array types in JAX"
 dynamic = ["version"]
@@ -51,7 +52,8 @@ requires = [
   "hatch-vcs",
   'jax>=0.5.3; python_version < "3.14"',
   'jax>=0.7.2; python_version >= "3.14"',
-  "quax>=0.3.2",
+  'quax>=0.3.2; python_version < "3.14"',
+  'quax>=0.4.0; python_version >= "3.14"',
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,14 +20,12 @@ classifiers = [
 ]
 dependencies = [
   "equinox>=0.13.2",
-  'jax>=0.5.3; python_version < "3.14"',
-  'jax>=0.7.2; python_version >= "3.14"',
-  "jaxtyping>=0.3.1",
+  "jax>=0.7.2",
+  "jaxtyping>=0.3.3",
   "optype>=0.8.0",
   'plum-dispatch>=2.5.7; python_version < "3.14"',
   'plum-dispatch>=2.9.0; python_version >= "3.14"',
-  'quax>=0.3.2; python_version < "3.14"',
-  'quax>=0.4.0; python_version >= "3.14"',
+  "quax>=0.4.0",
 ]
 description = "Pre-quaxed libraries for multiple dispatch over abstract array types in JAX"
 dynamic = ["version"]
@@ -47,14 +45,7 @@ quaxed-make-stubs = "quaxed._tools.make_stubs:main"
 
 [build-system]
 build-backend = "hatchling.build"
-requires = [
-  "hatchling",
-  "hatch-vcs",
-  'jax>=0.5.3; python_version < "3.14"',
-  'jax>=0.7.2; python_version >= "3.14"',
-  'quax>=0.3.2; python_version < "3.14"',
-  'quax>=0.4.0; python_version >= "3.14"',
-]
+requires      = ["hatchling", "hatch-vcs", "jax>=0.7.2", "quax>=0.4.0"]
 
 
 [dependency-groups]

--- a/tests/unit/test_numpy/test_jax.py
+++ b/tests/unit/test_numpy/test_jax.py
@@ -15,9 +15,13 @@ from quax._compat import JAX_VERSION
 import quaxed.numpy as qnp
 
 NUMPY_VERSION = Version(np.__version__)
+QUAX_VERSION = Version(quax.__version__)
 
+# quax v0.4.0 fixed https://github.com/patrick-kidger/quax/issues/58 for the
+# JAX-input path, so these functions now pass. Keep the xfail for older quax.
 xfail_quax58 = pytest.mark.xfail(
-    reason="https://github.com/patrick-kidger/quax/issues/58"
+    condition=Version("0.4") > QUAX_VERSION,
+    reason="https://github.com/patrick-kidger/quax/issues/58",
 )
 mark_todo = pytest.mark.skip("TODO")
 xfail_numpy_2_3_implicit_conversion = pytest.mark.xfail(

--- a/tests/unit/test_numpy/test_jax.py
+++ b/tests/unit/test_numpy/test_jax.py
@@ -15,14 +15,7 @@ from quax._compat import JAX_VERSION
 import quaxed.numpy as qnp
 
 NUMPY_VERSION = Version(np.__version__)
-QUAX_VERSION = Version(quax.__version__)
 
-# quax v0.4.0 fixed https://github.com/patrick-kidger/quax/issues/58 for the
-# JAX-input path, so these functions now pass. Keep the xfail for older quax.
-xfail_quax58 = pytest.mark.xfail(
-    condition=Version("0.4") > QUAX_VERSION,
-    reason="https://github.com/patrick-kidger/quax/issues/58",
-)
 mark_todo = pytest.mark.skip("TODO")
 xfail_numpy_2_3_implicit_conversion = pytest.mark.xfail(
     Version("2.3") <= NUMPY_VERSION,
@@ -93,7 +86,7 @@ xbool = jnp.array([True, False, True], dtype=bool)
         ("argpartition", (x, 1), {}),
         ("argsort", (x,), {}),
         *(
-            pytest.param("argwhere", (x,), {}, marks=xfail_quax58),
+            pytest.param("argwhere", (x,), {}),
             ("argwhere", (x,), {"size": x.size}),  # TODO: not need static size
         ),
         ("around", (x,), {}),
@@ -114,9 +107,7 @@ xbool = jnp.array([True, False, True], dtype=bool)
         ("average", (x,), {}),
         ("bartlett", (3,), {}),
         *(
-            pytest.param(
-                "bincount", (jnp.asarray([0, 1, 1, 2, 2, 2]),), {}, marks=xfail_quax58
-            ),
+            ("bincount", (jnp.asarray([0, 1, 1, 2, 2, 2]),), {}),
             ("bincount", (jnp.asarray([0, 1, 1, 2, 2, 2]),), {"length": 3}),
         ),
         ("bitwise_and", (xbool, xbool), {}),
@@ -139,14 +130,14 @@ xbool = jnp.array([True, False, True], dtype=bool)
         ),
         ("cbrt", (x,), {}),
         ("ceil", (x,), {}),
-        pytest.param("choose", (0, [x, x]), {}, marks=xfail_quax58),
+        pytest.param("choose", (0, [x, x]), {}),
         ("clip", (x, 1, 2), {}),
         ("column_stack", ([x, x],), {}),
         pytest.param("complex128", (1,), {}, marks=pytest.mark.xfail),
         ("complex64", (1,), {}),
         pytest.param("complex_", (1,), {}, marks=pytest.mark.xfail),
         pytest.param("complexfloating", (1,), {}, marks=pytest.mark.xfail),
-        pytest.param("compress", (xbool, x), {}, marks=xfail_quax58),
+        pytest.param("compress", (xbool, x), {}),
         ("concat", ([x, x],), {}),
         ("concatenate", ([x, x],), {}),
         ("conj", (x,), {}),
@@ -190,7 +181,7 @@ xbool = jnp.array([True, False, True], dtype=bool)
         ("exp2", (x,), {}),
         ("expand_dims", (x, 0), {}),
         ("expm1", (x,), {}),
-        pytest.param("extract", (jnp.array([True]), x), {}, marks=xfail_quax58),
+        pytest.param("extract", (jnp.array([True]), x), {}),
         ("eye", (2,), {}),
         ("fabs", (x,), {}),
         ("fill_diagonal", (jnp.eye(3), 2), {"inplace": False}),
@@ -201,7 +192,7 @@ xbool = jnp.array([True, False, True], dtype=bool)
             marks=[*xfail_deprecated_jax_0_9_0, skip_removed_jax_0_10_0],
         ),
         *(
-            pytest.param("flatnonzero", (x,), {}, marks=xfail_quax58),
+            pytest.param("flatnonzero", (x,), {}),
             ("flatnonzero", (x,), {"size": x.size}),
         ),
         ("flip", (x,), {}),
@@ -256,7 +247,7 @@ xbool = jnp.array([True, False, True], dtype=bool)
         ("insert", (x, 1, 2.0), {}),
         ("interp", (x[:, 0], x[:, 0], 2 * x[:, 0]), {}),
         *(
-            pytest.param("intersect1d", (x[:, 0], x[:, 0]), {}, marks=xfail_quax58),
+            pytest.param("intersect1d", (x[:, 0], x[:, 0]), {}),
             ("intersect1d", (x[:, 0], x[:, 0]), {"size": x[:, 0].size}),
         ),
         ("invert", (x.astype(int),), {}),
@@ -333,7 +324,7 @@ xbool = jnp.array([True, False, True], dtype=bool)
         ("negative", (x,), {}),
         ("nextafter", (x, y), {}),
         *(
-            pytest.param("nonzero", (x,), {}, marks=xfail_quax58),
+            pytest.param("nonzero", (x,), {}),
             ("nonzero", (x,), {"size": x.size}),
         ),
         ("not_equal", (x, y), {}),
@@ -366,12 +357,7 @@ xbool = jnp.array([True, False, True], dtype=bool)
         ("rad2deg", (x,), {}),
         ("radians", (x,), {}),
         ("ravel", (x,), {}),
-        pytest.param(
-            "ravel_multi_index",
-            (jnp.array([[0, 1], [0, 1]]), (2, 2)),
-            {},
-            marks=xfail_quax58,
-        ),
+        ("ravel_multi_index", (jnp.array([[0, 1], [0, 1]]), (2, 2)), {}),
         ("real", (x,), {}),
         ("reciprocal", (x,), {}),
         ("remainder", (x, y), {}),
@@ -383,7 +369,7 @@ xbool = jnp.array([True, False, True], dtype=bool)
         ("rint", (x,), {}),
         ("roll", (x, 4), {}),
         ("rollaxis", (x, -1), {}),
-        pytest.param("roots", (x[:, 0],), {}, marks=xfail_quax58),
+        pytest.param("roots", (x[:, 0],), {}),
         ("rot90", (x,), {}),
         ("round", (x,), {}),
         # pytest.param("round_", (x,), {}, marks=pytest.mark.deprecated),
@@ -392,11 +378,11 @@ xbool = jnp.array([True, False, True], dtype=bool)
         pytest.param("searchsorted", (x,), {}, marks=mark_todo),
         pytest.param("select", (x,), {}, marks=mark_todo),
         *(
-            pytest.param("setdiff1d", (x[:, 0], y[:, 0]), {}, marks=xfail_quax58),
+            pytest.param("setdiff1d", (x[:, 0], y[:, 0]), {}),
             ("setdiff1d", (x[:, 0], y[:, 0]), {"size": x[:, 0].size}),
         ),
         *(
-            pytest.param("setxor1d", (x[:, 0], y[:, 0]), {}, marks=xfail_quax58),
+            pytest.param("setxor1d", (x[:, 0], y[:, 0]), {}),
             ("setxor1d", (x[:, 0], y[:, 0]), {"size": x[:, 0].size}),
         ),
         ("shape", (x,), {}),
@@ -427,7 +413,7 @@ xbool = jnp.array([True, False, True], dtype=bool)
         ("transpose", (x,), {}),
         ("tril", (jnp.eye(4),), {}),
         ("tril_indices_from", (jnp.eye(4),), {}),
-        pytest.param(
+        (
             "trim_zeros",
             (
                 jnp.concatenate(
@@ -435,7 +421,6 @@ xbool = jnp.array([True, False, True], dtype=bool)
                 ),
             ),
             {},
-            marks=xfail_quax58,
         ),
         ("triu", (x,), {}),
         ("triu_indices_from", (x,), {}),
@@ -443,27 +428,27 @@ xbool = jnp.array([True, False, True], dtype=bool)
         ("trunc", (x,), {}),
         pytest.param("ufunc", (x,), {}, marks=mark_todo),
         *(
-            pytest.param("union1d", (x[:, 0], y[:, 0]), {}, marks=xfail_quax58),
+            pytest.param("union1d", (x[:, 0], y[:, 0]), {}),
             ("union1d", (x[:, 0], y[:, 0]), {"size": x[:, 0].size}),
         ),
         *(
-            pytest.param("unique", (x,), {}, marks=xfail_quax58),
+            pytest.param("unique", (x,), {}),
             ("unique", (x,), {"size": x.size}),
         ),
         *(
-            pytest.param("unique_all", (x,), {}, marks=xfail_quax58),
+            pytest.param("unique_all", (x,), {}),
             ("unique_all", (x,), {"size": x.size}),
         ),
         *(
-            pytest.param("unique_counts", (x,), {}, marks=xfail_quax58),
+            pytest.param("unique_counts", (x,), {}),
             ("unique_counts", (x,), {"size": x.size}),
         ),
         *(
-            pytest.param("unique_inverse", (x,), {}, marks=xfail_quax58),
+            pytest.param("unique_inverse", (x,), {}),
             ("unique_inverse", (x,), {"size": x.size}),
         ),
         *(
-            pytest.param("unique_values", (x,), {}, marks=xfail_quax58),
+            pytest.param("unique_values", (x,), {}),
             ("unique_values", (x,), {"size": x.size}),
         ),
         pytest.param(

--- a/uv.lock
+++ b/uv.lock
@@ -1645,38 +1645,15 @@ wheels = [
 
 [[package]]
 name = "quax"
-version = "0.3.2"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version < '3.12'",
-]
-dependencies = [
-    { name = "equinox" },
-    { name = "jax" },
-    { name = "jaxtyping" },
-    { name = "packaging" },
-    { name = "plum-dispatch", version = "2.5.7", source = { registry = "https://pypi.org/simple" } },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cf/15/66c9a1a32168726ba0f4adeb158e737a012e2a2ec19c638dfa24f7d4b0ab/quax-0.3.2.tar.gz", hash = "sha256:94a1656c55f813ca5f6e76b69f085c8dcc701673928f7616af1f2536da158f62", size = 171557, upload-time = "2026-05-04T13:43:07.09Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/28/08/ef6ff182c14090127dcb1cb0a7724e327b5a2ef0c0e3e8afcd1c5672441b/quax-0.3.2-py3-none-any.whl", hash = "sha256:d63ea1f6af06711ee256cfd38d19e980b9ded760c58c49a5ccb668d5f2a5c6c3", size = 39313, upload-time = "2026-05-04T13:43:05.48Z" },
-]
-
-[[package]]
-name = "quax"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-]
 dependencies = [
     { name = "equinox" },
     { name = "jax" },
     { name = "jaxtyping" },
     { name = "packaging" },
-    { name = "plum-dispatch", version = "2.9.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "plum-dispatch", version = "2.5.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "plum-dispatch", version = "2.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0c/06/445590bc5ec4f1ac493ac40456490a36136d43ed8d490a292144dbd938ad/quax-0.4.0.tar.gz", hash = "sha256:d1d8588a3b14b44954d23c957c90ac6ba5e6dc12b15f0b14b1f562ab983a7af2", size = 202233, upload-time = "2026-07-22T18:02:24.176Z" }
 wheels = [
@@ -1693,8 +1670,7 @@ dependencies = [
     { name = "optype" },
     { name = "plum-dispatch", version = "2.5.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
     { name = "plum-dispatch", version = "2.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "quax", version = "0.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "quax", version = "0.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "quax" },
 ]
 
 [package.dev-dependencies]
@@ -1762,14 +1738,12 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "equinox", specifier = ">=0.13.2" },
-    { name = "jax", marker = "python_full_version < '3.14'", specifier = ">=0.5.3" },
-    { name = "jax", marker = "python_full_version >= '3.14'", specifier = ">=0.7.2" },
-    { name = "jaxtyping", specifier = ">=0.3.1" },
+    { name = "jax", specifier = ">=0.7.2" },
+    { name = "jaxtyping", specifier = ">=0.3.3" },
     { name = "optype", specifier = ">=0.8.0" },
     { name = "plum-dispatch", marker = "python_full_version < '3.14'", specifier = ">=2.5.7" },
     { name = "plum-dispatch", marker = "python_full_version >= '3.14'", specifier = ">=2.9.0" },
-    { name = "quax", marker = "python_full_version < '3.14'", specifier = ">=0.3.2" },
-    { name = "quax", marker = "python_full_version >= '3.14'", specifier = ">=0.4.0" },
+    { name = "quax", specifier = ">=0.4.0" },
 ]
 
 [package.metadata.requires-dev]

--- a/uv.lock
+++ b/uv.lock
@@ -1645,7 +1645,7 @@ wheels = [
 
 [[package]]
 name = "quax"
-version = "0.4.0"
+version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "equinox" },
@@ -1655,9 +1655,9 @@ dependencies = [
     { name = "plum-dispatch", version = "2.5.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
     { name = "plum-dispatch", version = "2.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0c/06/445590bc5ec4f1ac493ac40456490a36136d43ed8d490a292144dbd938ad/quax-0.4.0.tar.gz", hash = "sha256:d1d8588a3b14b44954d23c957c90ac6ba5e6dc12b15f0b14b1f562ab983a7af2", size = 202233, upload-time = "2026-07-22T18:02:24.176Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/bf/b82c3951dc90de2ecead6c5bce06e7f4f492133d7a33cd3a0a2f50b7acf7/quax-0.4.1.tar.gz", hash = "sha256:d765430bf0f87a82311da7278e3e24148e854802fe765e6bc608383f059b2cb9", size = 202924, upload-time = "2026-07-22T19:51:31.037Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/e9/391ffa7a3c58998f47aa21414d74d817d611e4ee54300d2f70977402ccac/quax-0.4.0-py3-none-any.whl", hash = "sha256:1fa3d9ae506f2404bb1de09ecbcbf12205ec8cfd918dfcb1f65f3a8ce1a396e8", size = 58510, upload-time = "2026-07-22T18:02:22.807Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f4/71ff3476add83f10d17f5e2aaa7d6d48c0aabed39150b2630e1c523564a0/quax-0.4.1-py3-none-any.whl", hash = "sha256:1973f80b5f0e9687253e67ed766299226e4acbd986ada2e566db0f85bfb44b4e", size = 58940, upload-time = "2026-07-22T19:51:29.713Z" },
 ]
 
 [[package]]
@@ -1743,7 +1743,7 @@ requires-dist = [
     { name = "optype", specifier = ">=0.8.0" },
     { name = "plum-dispatch", marker = "python_full_version < '3.14'", specifier = ">=2.5.7" },
     { name = "plum-dispatch", marker = "python_full_version >= '3.14'", specifier = ">=2.9.0" },
-    { name = "quax", specifier = ">=0.4.0" },
+    { name = "quax", specifier = ">=0.4.1" },
 ]
 
 [package.metadata.requires-dev]

--- a/uv.lock
+++ b/uv.lock
@@ -1647,17 +1647,40 @@ wheels = [
 name = "quax"
 version = "0.3.2"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
+    "python_full_version < '3.12'",
+]
 dependencies = [
     { name = "equinox" },
     { name = "jax" },
     { name = "jaxtyping" },
     { name = "packaging" },
-    { name = "plum-dispatch", version = "2.5.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "plum-dispatch", version = "2.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "plum-dispatch", version = "2.5.7", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cf/15/66c9a1a32168726ba0f4adeb158e737a012e2a2ec19c638dfa24f7d4b0ab/quax-0.3.2.tar.gz", hash = "sha256:94a1656c55f813ca5f6e76b69f085c8dcc701673928f7616af1f2536da158f62", size = 171557, upload-time = "2026-05-04T13:43:07.09Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/28/08/ef6ff182c14090127dcb1cb0a7724e327b5a2ef0c0e3e8afcd1c5672441b/quax-0.3.2-py3-none-any.whl", hash = "sha256:d63ea1f6af06711ee256cfd38d19e980b9ded760c58c49a5ccb668d5f2a5c6c3", size = 39313, upload-time = "2026-05-04T13:43:05.48Z" },
+]
+
+[[package]]
+name = "quax"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+]
+dependencies = [
+    { name = "equinox" },
+    { name = "jax" },
+    { name = "jaxtyping" },
+    { name = "packaging" },
+    { name = "plum-dispatch", version = "2.9.0", source = { registry = "https://pypi.org/simple" } },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0c/06/445590bc5ec4f1ac493ac40456490a36136d43ed8d490a292144dbd938ad/quax-0.4.0.tar.gz", hash = "sha256:d1d8588a3b14b44954d23c957c90ac6ba5e6dc12b15f0b14b1f562ab983a7af2", size = 202233, upload-time = "2026-07-22T18:02:24.176Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/e9/391ffa7a3c58998f47aa21414d74d817d611e4ee54300d2f70977402ccac/quax-0.4.0-py3-none-any.whl", hash = "sha256:1fa3d9ae506f2404bb1de09ecbcbf12205ec8cfd918dfcb1f65f3a8ce1a396e8", size = 58510, upload-time = "2026-07-22T18:02:22.807Z" },
 ]
 
 [[package]]
@@ -1670,7 +1693,8 @@ dependencies = [
     { name = "optype" },
     { name = "plum-dispatch", version = "2.5.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
     { name = "plum-dispatch", version = "2.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "quax" },
+    { name = "quax", version = "0.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "quax", version = "0.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
 ]
 
 [package.dev-dependencies]
@@ -1744,7 +1768,8 @@ requires-dist = [
     { name = "optype", specifier = ">=0.8.0" },
     { name = "plum-dispatch", marker = "python_full_version < '3.14'", specifier = ">=2.5.7" },
     { name = "plum-dispatch", marker = "python_full_version >= '3.14'", specifier = ">=2.9.0" },
-    { name = "quax", specifier = ">=0.3.2" },
+    { name = "quax", marker = "python_full_version < '3.14'", specifier = ">=0.3.2" },
+    { name = "quax", marker = "python_full_version >= '3.14'", specifier = ">=0.4.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary

Require **`quax>=0.4.1`** unconditionally. quax 0.4.x supports Python 3.11+ — every version quaxed targets — adds Python 3.14 support (quax 0.3.x does not support 3.14), and brings performance work plus JAX 0.10/0.11 compatibility.

**Why 0.4.1 and not 0.4.0:** quax [0.4.0](https://github.com/nstarman/quax/releases/tag/v0.4.0) shipped a static-typing regression — its new `_FastModuleMeta` dropped `dataclass_transform`, so mypy stopped treating `quax.Value`/`ArrayValue` subclasses (e.g. quaxed's `MyArray` test helper) as dataclasses. [0.4.1](https://github.com/nstarman/quax/releases/tag/v0.4.1) fixes it ([nstarman/quax#196](https://github.com/nstarman/quax/pull/196)), so it is the true minimum.

A conditional split (`quax>=0.3.2; python_version < "3.14"`) was considered but rejected: since quax 0.4.x installs fine on 3.11–3.13, a resolver would pick it there anyway, so the split gave no real guarantee (raised in review).

## Consequences of the quax 0.4.1 floor

- **`jax>=0.7.2`** (was `jax>=0.5.3` on <3.14): required by quax 0.4.x, so the lower declaration was unenforceable. This drops support for JAX 0.5.3–0.7.1.
- **`jaxtyping>=0.3.3`** (was `>=0.3.1`): required by quax 0.4.x.
- **Tests**: quax 0.4.x fixes [patrick-kidger/quax#58](https://github.com/patrick-kidger/quax/issues/58) for the JAX-input path, so the now-obsolete `xfail_quax58` markers are removed from `test_jax.py`. The MyArray-input path still fails, so `test_myarray.py` is left unchanged.

Applied to both `[project].dependencies` and `[build-system].requires`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)