### PR TITLE
🔒 ci: harden cd.yml token permissions + fix labeler on fork PRs

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,6 +17,11 @@ concurrency:
 env:
   FORCE_COLOR: 3
 
+# Deny the workflow token by default (least privilege); each job below opts
+# into exactly the permissions it needs. Without this top-level block the token
+# falls back to the repository default, which may be write-all (CKV2_GHA_1).
+permissions: {}
+
 jobs:
   dist:
     name: Distribution build

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,13 @@
 name: Auto-label PRs
 
+# pull_request_target (not pull_request) so PRs from forks can be labelled: a
+# plain pull_request event gives fork PRs a read-only token that the
+# permissions below cannot elevate, which made the labeler fail with
+# "Resource not accessible by integration". This is safe because the job never
+# checks out or runs PR head code -- the labeler only reads the PR's
+# changed-file paths via the API and the trusted base-branch labeler config.
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 permissions:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,7 @@
 name: Auto-label PRs
 
-# pull_request_target (not pull_request) so PRs from forks can be labelled: a
-# plain pull_request event gives fork PRs a read-only token that the
+# pull_request_target (not pull_request) so PRs from forks can be labelled:
+# a plain pull_request event gives fork PRs a read-only token that the
 # permissions below cannot elevate, which made the labeler fail with
 # "Resource not accessible by integration". This is safe because the job never
 # checks out or runs PR head code -- the labeler only reads the PR's

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,8 +4,9 @@ name: Auto-label PRs
 # a plain pull_request event gives fork PRs a read-only token that the
 # permissions below cannot elevate, which made the labeler fail with
 # "Resource not accessible by integration". This is safe because the job never
-# checks out or runs PR head code -- the labeler only reads the PR's
-# changed-file paths via the API and the trusted base-branch labeler config.
+# runs PR head code -- the checkout below explicitly pins the trusted base
+# commit, and the labeler only reads the PR's changed-file paths via the API
+# plus that base-branch labeler config.
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]
@@ -21,6 +22,9 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # Explicitly check out the PR's base commit (trusted), not the fork
+          # head, so `pull_request_target`'s writable token never sees PR code.
+          ref: ${{ github.event.pull_request.base.sha }}
           persist-credentials: false
 
       - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0


### PR DESCRIPTION
Two GitHub Actions token-permission fixes.

## 1. Security alert CKV2_GHA_1 — `cd.yml` (`🔒 ci(cd)`)

*"Ensure top-level permissions are not set to write-all."* `cd.yml` declared per-job permissions but had **no top-level block**, so the `GITHUB_TOKEN` fell back to the repository default (potentially write-all). Added top-level `permissions: {}` (deny by default). No job loses anything — each already opts into what it needs: `dist` → `contents: read`, `test-publish`/`publish` → `id-token: write` (PyPI trusted publishing).

Addresses https://github.com/GalacticDynamics/quaxed/security/code-scanning/7.

## 2. Labeler CI failure on fork PRs — `labeler.yml` (`👷 ci(labeler)`)

The `Auto-label PRs` job failed with **"Resource not accessible by integration"** on fork PRs (e.g. #197). A `pull_request` event hands fork PRs a **read-only** token that the workflow's declared `pull-requests: write` / `issues: write` scopes **cannot elevate**. Switched the trigger to `pull_request_target`, which runs in the base-repo context with a writable token.

**Safe here:** the job never checks out or runs PR *head* code — under `pull_request_target` the checkout defaults to the trusted base branch, and the labeler only reads the PR's changed-file paths via the API plus the base-branch labeler config. No untrusted code executes with the elevated token.

Note: because the labeler workflow definition is taken from the base branch for `pull_request_target`, this takes effect for PRs (and re-runs) once merged to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)