### PR TITLE
⚡️ perf: restore dispatch caching on `full`

### DIFF
--- a/src/quaxed/numpy/_creation_functions.py
+++ b/src/quaxed/numpy/_creation_functions.py
@@ -114,14 +114,17 @@ def empty_like(
 # =============================================================================
 
 
-# NB: ``shape`` is annotated with the *unparametrized* ``tuple``. A subscripted
-# generic is not "faithful" in plum, and a single unfaithful signature disables
-# method caching for the whole function -- so ``full`` re-resolved its methods
-# on every call. ``tuple`` and ``tuple[int, ...]`` match exactly the same values
-# here; only the caching differs.
+# NB: ``shape`` is annotated with the *unparametrized* ``tuple``, against mypy's
+# `disallow_any_generics`. A parametrised builtin such as ``tuple[int, ...]`` is
+# not cacheable in plum -- matching it inspects the elements, so two values of
+# the same type can match differently -- and a single uncacheable signature
+# disables method caching for the whole function, making ``full`` re-resolve its
+# methods on every call. ``tuple`` and ``tuple[int, ...]`` accept exactly the
+# same values here; only the caching differs, so the parameter is traded for the
+# cache and the loss is confined to these two lines.
 @plum.dispatch
 def full(
-    shape: tuple | int,
+    shape: tuple | int,  # type: ignore[type-arg]
     fill_value: ArrayLike,
     *,
     dtype: DType | None = None,
@@ -131,7 +134,7 @@ def full(
 
 @plum.dispatch  # type: ignore[no-redef]
 def full(
-    shape: tuple | int,
+    shape: tuple | int,  # type: ignore[type-arg]
     *,
     fill_value: ArrayLike,
     dtype: DType | None = None,

--- a/src/quaxed/numpy/_creation_functions.py
+++ b/src/quaxed/numpy/_creation_functions.py
@@ -114,14 +114,10 @@ def empty_like(
 # =============================================================================
 
 
-# NB: ``shape`` is annotated with the *unparametrized* ``tuple``, against mypy's
-# `disallow_any_generics`. A parametrised builtin such as ``tuple[int, ...]`` is
-# not cacheable in plum -- matching it inspects the elements, so two values of
-# the same type can match differently -- and a single uncacheable signature
-# disables method caching for the whole function, making ``full`` re-resolve its
-# methods on every call. ``tuple`` and ``tuple[int, ...]`` accept exactly the
-# same values here; only the caching differs, so the parameter is traded for the
-# cache and the loss is confined to these two lines.
+# NB: ``shape`` is deliberately unparametrized. A parametrised builtin is not
+# cacheable in plum (matching inspects the elements), and one uncacheable
+# signature disables method caching for the whole function. Both spellings
+# accept the same values.
 @plum.dispatch
 def full(
     shape: tuple | int,  # type: ignore[type-arg]

--- a/src/quaxed/numpy/_creation_functions.py
+++ b/src/quaxed/numpy/_creation_functions.py
@@ -114,9 +114,14 @@ def empty_like(
 # =============================================================================
 
 
+# NB: ``shape`` is annotated with the *unparametrized* ``tuple``. A subscripted
+# generic is not "faithful" in plum, and a single unfaithful signature disables
+# method caching for the whole function -- so ``full`` re-resolved its methods
+# on every call. ``tuple`` and ``tuple[int, ...]`` match exactly the same values
+# here; only the caching differs.
 @plum.dispatch
 def full(
-    shape: tuple[int, ...] | int,
+    shape: tuple | int,
     fill_value: ArrayLike,
     *,
     dtype: DType | None = None,
@@ -126,7 +131,7 @@ def full(
 
 @plum.dispatch  # type: ignore[no-redef]
 def full(
-    shape: tuple[int, ...] | int,
+    shape: tuple | int,
     *,
     fill_value: ArrayLike,
     dtype: DType | None = None,


### PR DESCRIPTION
Found by a plum-faithfulness sweep across `quaxed`, `quaxed.numpy`, `quaxed.lax` and `quaxed.scipy`. `full` is the **only** non-faithful plum function in the package.

## The problem

Both `full` overloads annotate `shape` as `tuple[int, ...] | int`:

```python
@plum.dispatch
def full(shape: tuple[int, ...] | int, fill_value: ArrayLike, *, dtype=None) -> ArrayLike: ...
```

A *subscripted* generic is not "faithful" in plum, and **one** unfaithful signature disables method caching for the whole function — so `full` re-resolved its methods on every call. The bare `tuple` matches exactly the same values here; only the caching differs.

Neither overload carries a `type[...]` annotation, so dropping the subscript makes the function **fully** faithful rather than merely less unfaithful:

```
full faithful: True
```

## Measured

min-of-7, warmed:

| | before | after | |
|---|---|---|---|
| `full((2, 3), 1.5)` | 51.4 µs | 46.6 µs | 1.10× |
| `full(3, 1.5)` | 51.9 µs | 46.9 µs | 1.11× |
| `full((2, 3), fill_value=1.5)` | 68.3 µs | 59.8 µs | 1.14× |

**About 10%** — modest, because `jnp.full` itself dominates the call, and I'd rather state that plainly than dress it up. The stronger argument is that the caching loss is invisible at the call site and applies to every dispatch anyone adds to this function later. (For scale: the same annotation class cost 2× on `unxt`'s quantity constructor, where the surrounding work is cheaper — GalacticDynamics/unxt#849.)

## Dispatch unchanged

Tuple and int shapes, positional and keyword `fill_value`, and an explicit `dtype` all resolve to the same methods and produce arrays equal to `jnp.full`.

## Left alone

`full_like`, `empty_like` and friends annotate `shape: tuple[int, ...] | None`, but those parameters are **keyword-only** — they never take part in dispatch, so they cost nothing and are untouched.

## Verification

`pytest tests/unit/test_numpy/test_jax.py -k "argwhere or unique or full"` gives **6 failed / 8 passed both with and without this change** — the failures are pre-existing `argwhere` / `unique_*` cases (data-dependent shapes), confirmed by running the identical selection against a pristine checkout before attributing them. Full suite is 19 failed / 1024 passed on `main` for the same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)