### PR TITLE
💚 ci: bump build-and-inspect-python-package to v3.0.1

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
 
   test-publish:
     needs: [dist]


### PR DESCRIPTION
Fixes the `Distribution build` job, which currently fails on every PR ([example run](https://github.com/GalacticDynamics/quaxed/actions/runs/32064037337/job/95491692200?pr=202)):

```
Checking /tmp/baipp/dist/quaxed-0.10.5.dev35+gd72cac8e0-py3-none-any.whl:
ERROR InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

Hatchling now emits `Metadata-Version: 2.5`, and the `twine` bundled with baipp v2.18.0 predates support for it. v3.0.1 ships a `twine` that accepts it. This is the same fix already applied in `unxt` (pinned to the same SHA) and `galax`.

Unrelated to the content of #202 — that PR only added Markdown files. This failure reproduces on any PR against `main`.

## Artifact contract checked

The `test-publish` and `publish` jobs `download-artifact` by the name `Packages`, so a rename in v3 would have broken releases silently. It doesn't: v3.0.1's `action.yml` uploads `Packages${{ inputs.upload-name-suffix }}`, and with no suffix set that resolves to `Packages`. The pinned SHA `2abe76d` was confirmed against the `v3.0.1` tag via the API rather than copied from another repo.

`coordinax` is still on v2.18.0 and will hit the same failure — worth a matching bump there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)