### PR TITLE
🐛 fix(stubs): support jax 0.11.1 in the numpy stub generator

### DIFF
--- a/src/quaxed/_tools/make_numpy_stub.py
+++ b/src/quaxed/_tools/make_numpy_stub.py
@@ -282,18 +282,21 @@ def _add_typealias_imports(text: str, /) -> str:
     This function performs textual substitutions on the upstream `jax.numpy` stub:
 
     * Injects an import of ``quax`` alongside the existing ``os`` import.
-    * Extends the generic type variables with ``_ArrayValueT``, which is
-      bounded by ``quax.ArrayValue`` and is used to express value-preserving
-      overloads in function signatures.
+    * Declares ``_ArrayValueT``, which is bounded by ``quax.ArrayValue`` and is
+      used to express value-preserving overloads in function signatures.
 
     Critically, this does NOT widen the ``ArrayLike`` type alias. The original
     JAX ``ArrayLike`` remains unchanged. The overloads with ``_ArrayValueT``
     provide type preservation for ``ArrayValue`` subclasses, while the base
     ``ArrayLike`` overload remains for standard JAX array-like types.
 
+    ``TypeVar`` is imported under the private alias ``_TypeVar`` so that the
+    declaration does not depend on the upstream stub importing ``TypeVar``
+    itself: jax >= 0.11 no longer does.
+
     The transformation assumes the upstream stub follows the structure
     produced by JAX's stub generation scripts (in particular, that the
-    import blocks and ``_T`` definition appear exactly once).
+    ``import os`` line appears exactly once).
 
     Args:
         text: The complete contents of the upstream ``jax.numpy`` stub file.
@@ -304,15 +307,61 @@ def _add_typealias_imports(text: str, /) -> str:
         type variable, but with ``ArrayLike`` unchanged.
 
     """
-    text = text.replace("import os\n", "import os\nimport quax\n", 1)
     return text.replace(
-        "_T = TypeVar('_T')",
+        "import os\n",
         (
-            "_T = TypeVar('_T')\n"
-            "_ArrayValueT = TypeVar('_ArrayValueT', bound=quax.ArrayValue)"
+            "import os\n"
+            "import quax\n"
+            "from typing import TypeVar as _TypeVar\n"
+            "_ArrayValueT = _TypeVar('_ArrayValueT', bound=quax.ArrayValue)\n"
         ),
         1,
     )
+
+
+# RE_PEP695_ALIAS matches PEP 695 generic type aliases, e.g.
+#     type PadValueLike[T] = T | Sequence[T] | Sequence[Sequence[T]]
+# Only plain identifier type parameters are matched; anything fancier (bounds,
+# defaults, TypeVarTuples) is left alone rather than silently mangled.
+RE_PEP695_ALIAS = re.compile(
+    r"^type (?P<name>\w+)\[(?P<params>\w+(?:,\s*\w+)*)\] = (?P<rhs>.+)$",
+    re.MULTILINE,
+)
+
+
+def _downgrade_pep695_aliases(text: str, /) -> str:
+    r"""Rewrite PEP 695 type aliases into Python 3.11-compatible syntax.
+
+    jax >= 0.11 requires Python >= 3.12 and its stub uses ``type X[T] = ...``.
+    quaxed supports Python 3.11, and a wheel built on 3.12+ must still ship a
+    stub that a 3.11-targeted type checker can parse, so each generic alias is
+    rewritten as an explicit ``TypeVar`` plus a plain assignment.
+
+    Args:
+        text: The stub text to process.
+
+    Returns
+    -------
+        The stub text with PEP 695 type aliases downgraded.
+
+    Examples
+    --------
+        >>> _downgrade_pep695_aliases("type Pair[T] = tuple[T, T]")
+        "_Pair_T = _TypeVar('_Pair_T')\nPair = tuple[_Pair_T, _Pair_T]"
+
+    """
+
+    def repl(match: re.Match[str], /) -> str:
+        name = match.group("name")
+        rhs = match.group("rhs")
+        decls = []
+        for param in (p.strip() for p in match.group("params").split(",")):
+            typevar = f"_{name}_{param}"
+            decls.append(f"{typevar} = _TypeVar('{typevar}')")
+            rhs = re.sub(rf"\b{param}\b", typevar, rhs)
+        return "\n".join([*decls, f"{name} = {rhs}"])
+
+    return RE_PEP695_ALIAS.sub(repl, text)
 
 
 def _replace_binary_ufunc(text: str, /) -> str:
@@ -813,6 +862,7 @@ def generate_numpy_stub(output: Path, /) -> None:
     upstream = Path(jnp.__file__).with_suffix(".pyi")
     text = upstream.read_text(encoding="utf-8")
     text = _add_typealias_imports(text)
+    text = _downgrade_pep695_aliases(text)
     text = _replace_binary_ufunc(text)
     text = _rewrite_single_arraylike_param(text)
     text = _rewrite_multi_param_first_arraylike(text)

--- a/tests/unit/test_numpy/test_jax.py
+++ b/tests/unit/test_numpy/test_jax.py
@@ -6,6 +6,7 @@ import jax.numpy as jnp
 import jax.random as jr
 import jax.tree as jtu
 import jax.tree_util as jt
+import ml_dtypes
 import numpy as np
 import pytest
 import quax
@@ -15,6 +16,7 @@ from quax._compat import JAX_VERSION
 import quaxed.numpy as qnp
 
 NUMPY_VERSION = Version(np.__version__)
+ML_DTYPES_VERSION = Version(ml_dtypes.__version__)
 
 mark_todo = pytest.mark.skip("TODO")
 xfail_numpy_2_3_implicit_conversion = pytest.mark.xfail(
@@ -28,6 +30,17 @@ xfail_numpy_2_3_implicit_conversion = pytest.mark.xfail(
 xfail_numpy_2_3_implicit_conversion_jax = (
     pytest.mark.xfail(
         Version("2.3") <= NUMPY_VERSION,
+        raises=DeprecationWarning,
+        reason="deprecated in NumPy 2.3: implicit array-to-dtype conversion",
+        strict=True,
+    ),
+    pytest.mark.filterwarnings("error::DeprecationWarning"),
+)
+# `jnp.finfo`/`jnp.iinfo` hit the same deprecation via `ml_dtypes`, which stopped
+# passing the array through to NumPy in 0.6.0.
+xfail_ml_dtypes_implicit_conversion = (
+    pytest.mark.xfail(
+        Version("2.3") <= NUMPY_VERSION and Version("0.6") > ML_DTYPES_VERSION,
         raises=DeprecationWarning,
         reason="deprecated in NumPy 2.3: implicit array-to-dtype conversion",
         strict=True,
@@ -517,8 +530,8 @@ def test_euler_gamma():
     assert qnp.euler_gamma == jnp.euler_gamma
 
 
-@xfail_numpy_2_3_implicit_conversion_jax[0]
-@xfail_numpy_2_3_implicit_conversion_jax[1]
+@xfail_ml_dtypes_implicit_conversion[0]
+@xfail_ml_dtypes_implicit_conversion[1]
 def test_finfo():
     """Test `quaxed.numpy.finfo`."""
     assert jnp.all(qnp.finfo(x) == jnp.finfo(x))
@@ -550,8 +563,8 @@ def test_get_printoptions():
     assert jnp.all(qnp.get_printoptions() == jnp.get_printoptions())
 
 
-@xfail_numpy_2_3_implicit_conversion_jax[0]
-@xfail_numpy_2_3_implicit_conversion_jax[1]
+@xfail_ml_dtypes_implicit_conversion[0]
+@xfail_ml_dtypes_implicit_conversion[1]
 def test_iinfo():
     """Test `quaxed.numpy.iinfo`."""
     got = qnp.iinfo(x.astype(int))


### PR DESCRIPTION
Fixes the CI failure seen on #202 (and on every PR / push since ~20:29 UTC today):

```
src/quaxed/numpy/__init__.pyi:1636: error: Invalid syntax  [syntax]
```

## Cause

[jax 0.11.1](https://pypi.org/project/jax/0.11.1/) was released today at 20:29 UTC — between the last green run on `main` (20:25) and #202's run (20:46). It changed `jax/numpy/__init__.pyi` in two ways that the stub generator depends on:

1. `PadValueLike` became a PEP 695 generic alias — `type PadValueLike[T] = T | Sequence[T] | Sequence[Sequence[T]]`. `[tool.mypy] python_version = "3.11"`, and that syntax needs 3.12+, hence the `Invalid syntax` error. (jax 0.11.0 did *not* have this; only 0.11.1.)
2. The module-level `TypeVar` import and `_T = TypeVar('_T')` are gone. `_add_typealias_imports` anchored the `_ArrayValueT` declaration on that exact line, so `_ArrayValueT` was silently never declared — every generated overload referenced an undefined name. mypy never got that far because the syntax error stopped it.

The stub is generated by the hatch build hook from whatever jax the *build* environment resolves, which is unpinned in `build-system.requires`. jax 0.11 requires Python >= 3.12, so this hits every job on 3.12/3.13/3.14 while the 3.11 jobs still resolve jax 0.10 and stay green — matching the failure pattern on #202 exactly.

## Fix

- Declare `_ArrayValueT` using a privately aliased `_TypeVar`, injected right after `import quax`, so it no longer depends on upstream declaring `_T` or importing `TypeVar`.
- Add `_downgrade_pep695_aliases`: rewrite `type X[T] = ...` into an explicit `TypeVar` plus a plain assignment. quaxed supports Python 3.11, so a wheel built on 3.12+ must still ship a stub a 3.11-targeted type checker can parse. Only plain identifier type parameters are matched; anything fancier (bounds, defaults, `TypeVarTuple`) is left untouched so it fails loudly rather than being silently mangled.

## Verification

Regenerated the stub against **both** jax 0.10.0 (Python 3.11) and jax 0.11.1 (Python 3.12) and ran `mypy src/quaxed tests/static` (the `mypy_test` nox session) on each — clean in both. Reproduced the original failure first, at the same line number, to confirm the diagnosis. `prek run` passes.

## Not addressed

The build environment resolving a newer jax than the locked runtime jax is a standing mismatch — the stub for a locked jax 0.10.0 env is currently generated from jax 0.11.1. This PR makes the generator tolerate that; pinning the two together (e.g. a uv build constraint) is a separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)