### PR TITLE
💚 ci: bump build-and-inspect-python-package to v3.0.1

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: hynek/build-and-inspect-python-package@fe0a0fb1925ca263d076ca4f2c13e93a6e92a33e # v2.17.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
 
   test-publish:
     needs: [dist]

--- a/src/quaxed/_tools/make_numpy_stub.py
+++ b/src/quaxed/_tools/make_numpy_stub.py
@@ -282,18 +282,21 @@ def _add_typealias_imports(text: str, /) -> str:
     This function performs textual substitutions on the upstream `jax.numpy` stub:
 
     * Injects an import of ``quax`` alongside the existing ``os`` import.
-    * Extends the generic type variables with ``_ArrayValueT``, which is
-      bounded by ``quax.ArrayValue`` and is used to express value-preserving
-      overloads in function signatures.
+    * Declares ``_ArrayValueT``, which is bounded by ``quax.ArrayValue`` and is
+      used to express value-preserving overloads in function signatures.
 
     Critically, this does NOT widen the ``ArrayLike`` type alias. The original
     JAX ``ArrayLike`` remains unchanged. The overloads with ``_ArrayValueT``
     provide type preservation for ``ArrayValue`` subclasses, while the base
     ``ArrayLike`` overload remains for standard JAX array-like types.
 
+    ``TypeVar`` is imported under the private alias ``_TypeVar`` so that the
+    declaration does not depend on the upstream stub importing ``TypeVar``
+    itself: jax >= 0.11 no longer does.
+
     The transformation assumes the upstream stub follows the structure
     produced by JAX's stub generation scripts (in particular, that the
-    import blocks and ``_T`` definition appear exactly once).
+    ``import os`` line appears exactly once).
 
     Args:
         text: The complete contents of the upstream ``jax.numpy`` stub file.
@@ -304,15 +307,61 @@ def _add_typealias_imports(text: str, /) -> str:
         type variable, but with ``ArrayLike`` unchanged.
 
     """
-    text = text.replace("import os\n", "import os\nimport quax\n", 1)
     return text.replace(
-        "_T = TypeVar('_T')",
+        "import os\n",
         (
-            "_T = TypeVar('_T')\n"
-            "_ArrayValueT = TypeVar('_ArrayValueT', bound=quax.ArrayValue)"
+            "import os\n"
+            "import quax\n"
+            "from typing import TypeVar as _TypeVar\n"
+            "_ArrayValueT = _TypeVar('_ArrayValueT', bound=quax.ArrayValue)\n"
         ),
         1,
     )
+
+
+# RE_PEP695_ALIAS matches PEP 695 generic type aliases, e.g.
+#     type PadValueLike[T] = T | Sequence[T] | Sequence[Sequence[T]]
+# Only plain identifier type parameters are matched; anything fancier (bounds,
+# defaults, TypeVarTuples) is left alone rather than silently mangled.
+RE_PEP695_ALIAS = re.compile(
+    r"^type (?P<name>\w+)\[(?P<params>\w+(?:,\s*\w+)*)\] = (?P<rhs>.+)$",
+    re.MULTILINE,
+)
+
+
+def _downgrade_pep695_aliases(text: str, /) -> str:
+    r"""Rewrite PEP 695 type aliases into Python 3.11-compatible syntax.
+
+    jax >= 0.11 requires Python >= 3.12 and its stub uses ``type X[T] = ...``.
+    quaxed supports Python 3.11, and a wheel built on 3.12+ must still ship a
+    stub that a 3.11-targeted type checker can parse, so each generic alias is
+    rewritten as an explicit ``TypeVar`` plus a plain assignment.
+
+    Args:
+        text: The stub text to process.
+
+    Returns
+    -------
+        The stub text with PEP 695 type aliases downgraded.
+
+    Examples
+    --------
+        >>> _downgrade_pep695_aliases("type Pair[T] = tuple[T, T]")
+        "_Pair_T = _TypeVar('_Pair_T')\nPair = tuple[_Pair_T, _Pair_T]"
+
+    """
+
+    def repl(match: re.Match[str], /) -> str:
+        name = match.group("name")
+        rhs = match.group("rhs")
+        decls = []
+        for param in (p.strip() for p in match.group("params").split(",")):
+            typevar = f"_{name}_{param}"
+            decls.append(f"{typevar} = _TypeVar('{typevar}')")
+            rhs = re.sub(rf"\b{param}\b", typevar, rhs)
+        return "\n".join([*decls, f"{name} = {rhs}"])
+
+    return RE_PEP695_ALIAS.sub(repl, text)
 
 
 def _replace_binary_ufunc(text: str, /) -> str:
@@ -813,6 +862,7 @@ def generate_numpy_stub(output: Path, /) -> None:
     upstream = Path(jnp.__file__).with_suffix(".pyi")
     text = upstream.read_text(encoding="utf-8")
     text = _add_typealias_imports(text)
+    text = _downgrade_pep695_aliases(text)
     text = _replace_binary_ufunc(text)
     text = _rewrite_single_arraylike_param(text)
     text = _rewrite_multi_param_first_arraylike(text)

--- a/src/quaxed/lax/_patch.py
+++ b/src/quaxed/lax/_patch.py
@@ -12,5 +12,5 @@ from jaxtyping import Array, ArrayLike
 
 @quax.register(lax.scan_p)
 def scan_p(*args: ArrayLike, **kw: Any) -> Array:
-    """Patched implementation of lax.map."""
+    """Patched implementation of lax.scan."""
     return lax.scan_p.bind(*args, **kw)  # type: ignore[no-untyped-call]

--- a/tests/myarray.py
+++ b/tests/myarray.py
@@ -1490,6 +1490,15 @@ def squeeze_p(x: MyArray, **kw: Any) -> MyArray:
 
 # ==============================================================================
 
+if Version("0.10.1") <= JAX_VERSION:
+
+    @quax.register(lax.stack_p)  # type: ignore[attr-defined]
+    def stack_p(*args: MyArray, **kw: Any) -> MyArray:
+        return MyArray(lax.stack_p.bind(*[arg.array for arg in args], **kw))  # type: ignore[attr-defined]
+
+
+# ==============================================================================
+
 
 @quax.register(lax.stop_gradient_p)
 def stop_gradient_p(x: MyArray) -> MyArray:

--- a/tests/unit/test_numpy/test_jax.py
+++ b/tests/unit/test_numpy/test_jax.py
@@ -6,6 +6,7 @@ import jax.numpy as jnp
 import jax.random as jr
 import jax.tree as jtu
 import jax.tree_util as jt
+import ml_dtypes
 import numpy as np
 import pytest
 import quax
@@ -15,6 +16,7 @@ from quax._compat import JAX_VERSION
 import quaxed.numpy as qnp
 
 NUMPY_VERSION = Version(np.__version__)
+ML_DTYPES_VERSION = Version(ml_dtypes.__version__)
 
 xfail_quax58 = pytest.mark.xfail(
     reason="https://github.com/patrick-kidger/quax/issues/58"
@@ -31,6 +33,17 @@ xfail_numpy_2_3_implicit_conversion = pytest.mark.xfail(
 xfail_numpy_2_3_implicit_conversion_jax = (
     pytest.mark.xfail(
         Version("2.3") <= NUMPY_VERSION,
+        raises=DeprecationWarning,
+        reason="deprecated in NumPy 2.3: implicit array-to-dtype conversion",
+        strict=True,
+    ),
+    pytest.mark.filterwarnings("error::DeprecationWarning"),
+)
+# `jnp.finfo`/`jnp.iinfo` hit the same deprecation via `ml_dtypes`, which stopped
+# passing the array through to NumPy in 0.6.0.
+xfail_ml_dtypes_implicit_conversion = (
+    pytest.mark.xfail(
+        Version("2.3") <= NUMPY_VERSION and Version("0.6") > ML_DTYPES_VERSION,
         raises=DeprecationWarning,
         reason="deprecated in NumPy 2.3: implicit array-to-dtype conversion",
         strict=True,
@@ -528,8 +541,8 @@ def test_euler_gamma():
     assert qnp.euler_gamma == jnp.euler_gamma
 
 
-@xfail_numpy_2_3_implicit_conversion_jax[0]
-@xfail_numpy_2_3_implicit_conversion_jax[1]
+@xfail_ml_dtypes_implicit_conversion[0]
+@xfail_ml_dtypes_implicit_conversion[1]
 def test_finfo():
     """Test `quaxed.numpy.finfo`."""
     assert jnp.all(qnp.finfo(x) == jnp.finfo(x))
@@ -561,8 +574,8 @@ def test_get_printoptions():
     assert jnp.all(qnp.get_printoptions() == jnp.get_printoptions())
 
 
-@xfail_numpy_2_3_implicit_conversion_jax[0]
-@xfail_numpy_2_3_implicit_conversion_jax[1]
+@xfail_ml_dtypes_implicit_conversion[0]
+@xfail_ml_dtypes_implicit_conversion[1]
 def test_iinfo():
     """Test `quaxed.numpy.iinfo`."""
     got = qnp.iinfo(x.astype(int))

--- a/tests/unit/test_numpy/test_jax.py
+++ b/tests/unit/test_numpy/test_jax.py
@@ -18,9 +18,6 @@ import quaxed.numpy as qnp
 NUMPY_VERSION = Version(np.__version__)
 ML_DTYPES_VERSION = Version(ml_dtypes.__version__)
 
-xfail_quax58 = pytest.mark.xfail(
-    reason="https://github.com/patrick-kidger/quax/issues/58"
-)
 mark_todo = pytest.mark.skip("TODO")
 xfail_numpy_2_3_implicit_conversion = pytest.mark.xfail(
     Version("2.3") <= NUMPY_VERSION,
@@ -102,7 +99,7 @@ xbool = jnp.array([True, False, True], dtype=bool)
         ("argpartition", (x, 1), {}),
         ("argsort", (x,), {}),
         *(
-            pytest.param("argwhere", (x,), {}, marks=xfail_quax58),
+            ("argwhere", (x,), {}),
             ("argwhere", (x,), {"size": x.size}),  # TODO: not need static size
         ),
         ("around", (x,), {}),
@@ -123,9 +120,7 @@ xbool = jnp.array([True, False, True], dtype=bool)
         ("average", (x,), {}),
         ("bartlett", (3,), {}),
         *(
-            pytest.param(
-                "bincount", (jnp.asarray([0, 1, 1, 2, 2, 2]),), {}, marks=xfail_quax58
-            ),
+            ("bincount", (jnp.asarray([0, 1, 1, 2, 2, 2]),), {}),
             ("bincount", (jnp.asarray([0, 1, 1, 2, 2, 2]),), {"length": 3}),
         ),
         ("bitwise_and", (xbool, xbool), {}),
@@ -148,14 +143,14 @@ xbool = jnp.array([True, False, True], dtype=bool)
         ),
         ("cbrt", (x,), {}),
         ("ceil", (x,), {}),
-        pytest.param("choose", (0, [x, x]), {}, marks=xfail_quax58),
+        pytest.param("choose", (0, [x, x]), {}),
         ("clip", (x, 1, 2), {}),
         ("column_stack", ([x, x],), {}),
         pytest.param("complex128", (1,), {}, marks=pytest.mark.xfail),
         ("complex64", (1,), {}),
         pytest.param("complex_", (1,), {}, marks=pytest.mark.xfail),
         pytest.param("complexfloating", (1,), {}, marks=pytest.mark.xfail),
-        pytest.param("compress", (xbool, x), {}, marks=xfail_quax58),
+        pytest.param("compress", (xbool, x), {}),
         ("concat", ([x, x],), {}),
         ("concatenate", ([x, x],), {}),
         ("conj", (x,), {}),
@@ -199,7 +194,7 @@ xbool = jnp.array([True, False, True], dtype=bool)
         ("exp2", (x,), {}),
         ("expand_dims", (x, 0), {}),
         ("expm1", (x,), {}),
-        pytest.param("extract", (jnp.array([True]), x), {}, marks=xfail_quax58),
+        pytest.param("extract", (jnp.array([True]), x), {}),
         ("eye", (2,), {}),
         ("fabs", (x,), {}),
         ("fill_diagonal", (jnp.eye(3), 2), {"inplace": False}),
@@ -210,7 +205,7 @@ xbool = jnp.array([True, False, True], dtype=bool)
             marks=[*xfail_deprecated_jax_0_9_0, skip_removed_jax_0_10_0],
         ),
         *(
-            pytest.param("flatnonzero", (x,), {}, marks=xfail_quax58),
+            pytest.param("flatnonzero", (x,), {}),
             ("flatnonzero", (x,), {"size": x.size}),
         ),
         ("flip", (x,), {}),
@@ -265,7 +260,7 @@ xbool = jnp.array([True, False, True], dtype=bool)
         ("insert", (x, 1, 2.0), {}),
         ("interp", (x[:, 0], x[:, 0], 2 * x[:, 0]), {}),
         *(
-            pytest.param("intersect1d", (x[:, 0], x[:, 0]), {}, marks=xfail_quax58),
+            pytest.param("intersect1d", (x[:, 0], x[:, 0]), {}),
             ("intersect1d", (x[:, 0], x[:, 0]), {"size": x[:, 0].size}),
         ),
         ("invert", (x.astype(int),), {}),
@@ -342,7 +337,7 @@ xbool = jnp.array([True, False, True], dtype=bool)
         ("negative", (x,), {}),
         ("nextafter", (x, y), {}),
         *(
-            pytest.param("nonzero", (x,), {}, marks=xfail_quax58),
+            pytest.param("nonzero", (x,), {}),
             ("nonzero", (x,), {"size": x.size}),
         ),
         ("not_equal", (x, y), {}),
@@ -375,12 +370,7 @@ xbool = jnp.array([True, False, True], dtype=bool)
         ("rad2deg", (x,), {}),
         ("radians", (x,), {}),
         ("ravel", (x,), {}),
-        pytest.param(
-            "ravel_multi_index",
-            (jnp.array([[0, 1], [0, 1]]), (2, 2)),
-            {},
-            marks=xfail_quax58,
-        ),
+        ("ravel_multi_index", (jnp.array([[0, 1], [0, 1]]), (2, 2)), {}),
         ("real", (x,), {}),
         ("reciprocal", (x,), {}),
         ("remainder", (x, y), {}),
@@ -392,7 +382,7 @@ xbool = jnp.array([True, False, True], dtype=bool)
         ("rint", (x,), {}),
         ("roll", (x, 4), {}),
         ("rollaxis", (x, -1), {}),
-        pytest.param("roots", (x[:, 0],), {}, marks=xfail_quax58),
+        pytest.param("roots", (x[:, 0],), {}),
         ("rot90", (x,), {}),
         ("round", (x,), {}),
         # pytest.param("round_", (x,), {}, marks=pytest.mark.deprecated),
@@ -401,11 +391,11 @@ xbool = jnp.array([True, False, True], dtype=bool)
         pytest.param("searchsorted", (x,), {}, marks=mark_todo),
         pytest.param("select", (x,), {}, marks=mark_todo),
         *(
-            pytest.param("setdiff1d", (x[:, 0], y[:, 0]), {}, marks=xfail_quax58),
+            pytest.param("setdiff1d", (x[:, 0], y[:, 0]), {}),
             ("setdiff1d", (x[:, 0], y[:, 0]), {"size": x[:, 0].size}),
         ),
         *(
-            pytest.param("setxor1d", (x[:, 0], y[:, 0]), {}, marks=xfail_quax58),
+            pytest.param("setxor1d", (x[:, 0], y[:, 0]), {}),
             ("setxor1d", (x[:, 0], y[:, 0]), {"size": x[:, 0].size}),
         ),
         ("shape", (x,), {}),
@@ -436,7 +426,7 @@ xbool = jnp.array([True, False, True], dtype=bool)
         ("transpose", (x,), {}),
         ("tril", (jnp.eye(4),), {}),
         ("tril_indices_from", (jnp.eye(4),), {}),
-        pytest.param(
+        (
             "trim_zeros",
             (
                 jnp.concatenate(
@@ -444,7 +434,6 @@ xbool = jnp.array([True, False, True], dtype=bool)
                 ),
             ),
             {},
-            marks=xfail_quax58,
         ),
         ("triu", (x,), {}),
         ("triu_indices_from", (x,), {}),
@@ -452,27 +441,27 @@ xbool = jnp.array([True, False, True], dtype=bool)
         ("trunc", (x,), {}),
         pytest.param("ufunc", (x,), {}, marks=mark_todo),
         *(
-            pytest.param("union1d", (x[:, 0], y[:, 0]), {}, marks=xfail_quax58),
+            pytest.param("union1d", (x[:, 0], y[:, 0]), {}),
             ("union1d", (x[:, 0], y[:, 0]), {"size": x[:, 0].size}),
         ),
         *(
-            pytest.param("unique", (x,), {}, marks=xfail_quax58),
+            pytest.param("unique", (x,), {}),
             ("unique", (x,), {"size": x.size}),
         ),
         *(
-            pytest.param("unique_all", (x,), {}, marks=xfail_quax58),
+            pytest.param("unique_all", (x,), {}),
             ("unique_all", (x,), {"size": x.size}),
         ),
         *(
-            pytest.param("unique_counts", (x,), {}, marks=xfail_quax58),
+            pytest.param("unique_counts", (x,), {}),
             ("unique_counts", (x,), {"size": x.size}),
         ),
         *(
-            pytest.param("unique_inverse", (x,), {}, marks=xfail_quax58),
+            pytest.param("unique_inverse", (x,), {}),
             ("unique_inverse", (x,), {"size": x.size}),
         ),
         *(
-            pytest.param("unique_values", (x,), {}, marks=xfail_quax58),
+            pytest.param("unique_values", (x,), {}),
             ("unique_values", (x,), {"size": x.size}),
         ),
         pytest.param(

--- a/tests/unit/test_numpy/test_jax.py
+++ b/tests/unit/test_numpy/test_jax.py
@@ -17,7 +17,14 @@ import quaxed.numpy as qnp
 
 NUMPY_VERSION = Version(np.__version__)
 ML_DTYPES_VERSION = Version(ml_dtypes.__version__)
+QUAX_VERSION = Version(quax.__version__)
 
+# Fixed in quax 0.4.0 (JAX-input dispatch path); MyArray-specific cases in
+# test_myarray.py remain unfixed and are xfailed unconditionally there.
+xfail_quax58 = pytest.mark.xfail(
+    Version("0.4") > QUAX_VERSION,
+    reason="https://github.com/patrick-kidger/quax/issues/58",
+)
 mark_todo = pytest.mark.skip("TODO")
 xfail_numpy_2_3_implicit_conversion = pytest.mark.xfail(
     Version("2.3") <= NUMPY_VERSION,
@@ -99,7 +106,7 @@ xbool = jnp.array([True, False, True], dtype=bool)
         ("argpartition", (x, 1), {}),
         ("argsort", (x,), {}),
         *(
-            ("argwhere", (x,), {}),
+            pytest.param("argwhere", (x,), {}, marks=xfail_quax58),
             ("argwhere", (x,), {"size": x.size}),  # TODO: not need static size
         ),
         ("around", (x,), {}),
@@ -120,7 +127,9 @@ xbool = jnp.array([True, False, True], dtype=bool)
         ("average", (x,), {}),
         ("bartlett", (3,), {}),
         *(
-            ("bincount", (jnp.asarray([0, 1, 1, 2, 2, 2]),), {}),
+            pytest.param(
+                "bincount", (jnp.asarray([0, 1, 1, 2, 2, 2]),), {}, marks=xfail_quax58
+            ),
             ("bincount", (jnp.asarray([0, 1, 1, 2, 2, 2]),), {"length": 3}),
         ),
         ("bitwise_and", (xbool, xbool), {}),
@@ -143,14 +152,14 @@ xbool = jnp.array([True, False, True], dtype=bool)
         ),
         ("cbrt", (x,), {}),
         ("ceil", (x,), {}),
-        pytest.param("choose", (0, [x, x]), {}),
+        pytest.param("choose", (0, [x, x]), {}, marks=xfail_quax58),
         ("clip", (x, 1, 2), {}),
         ("column_stack", ([x, x],), {}),
         pytest.param("complex128", (1,), {}, marks=pytest.mark.xfail),
         ("complex64", (1,), {}),
         pytest.param("complex_", (1,), {}, marks=pytest.mark.xfail),
         pytest.param("complexfloating", (1,), {}, marks=pytest.mark.xfail),
-        pytest.param("compress", (xbool, x), {}),
+        pytest.param("compress", (xbool, x), {}, marks=xfail_quax58),
         ("concat", ([x, x],), {}),
         ("concatenate", ([x, x],), {}),
         ("conj", (x,), {}),
@@ -194,7 +203,7 @@ xbool = jnp.array([True, False, True], dtype=bool)
         ("exp2", (x,), {}),
         ("expand_dims", (x, 0), {}),
         ("expm1", (x,), {}),
-        pytest.param("extract", (jnp.array([True]), x), {}),
+        pytest.param("extract", (jnp.array([True]), x), {}, marks=xfail_quax58),
         ("eye", (2,), {}),
         ("fabs", (x,), {}),
         ("fill_diagonal", (jnp.eye(3), 2), {"inplace": False}),
@@ -205,7 +214,7 @@ xbool = jnp.array([True, False, True], dtype=bool)
             marks=[*xfail_deprecated_jax_0_9_0, skip_removed_jax_0_10_0],
         ),
         *(
-            pytest.param("flatnonzero", (x,), {}),
+            pytest.param("flatnonzero", (x,), {}, marks=xfail_quax58),
             ("flatnonzero", (x,), {"size": x.size}),
         ),
         ("flip", (x,), {}),
@@ -260,7 +269,7 @@ xbool = jnp.array([True, False, True], dtype=bool)
         ("insert", (x, 1, 2.0), {}),
         ("interp", (x[:, 0], x[:, 0], 2 * x[:, 0]), {}),
         *(
-            pytest.param("intersect1d", (x[:, 0], x[:, 0]), {}),
+            pytest.param("intersect1d", (x[:, 0], x[:, 0]), {}, marks=xfail_quax58),
             ("intersect1d", (x[:, 0], x[:, 0]), {"size": x[:, 0].size}),
         ),
         ("invert", (x.astype(int),), {}),
@@ -337,7 +346,7 @@ xbool = jnp.array([True, False, True], dtype=bool)
         ("negative", (x,), {}),
         ("nextafter", (x, y), {}),
         *(
-            pytest.param("nonzero", (x,), {}),
+            pytest.param("nonzero", (x,), {}, marks=xfail_quax58),
             ("nonzero", (x,), {"size": x.size}),
         ),
         ("not_equal", (x, y), {}),
@@ -370,7 +379,12 @@ xbool = jnp.array([True, False, True], dtype=bool)
         ("rad2deg", (x,), {}),
         ("radians", (x,), {}),
         ("ravel", (x,), {}),
-        ("ravel_multi_index", (jnp.array([[0, 1], [0, 1]]), (2, 2)), {}),
+        pytest.param(
+            "ravel_multi_index",
+            (jnp.array([[0, 1], [0, 1]]), (2, 2)),
+            {},
+            marks=xfail_quax58,
+        ),
         ("real", (x,), {}),
         ("reciprocal", (x,), {}),
         ("remainder", (x, y), {}),
@@ -382,7 +396,7 @@ xbool = jnp.array([True, False, True], dtype=bool)
         ("rint", (x,), {}),
         ("roll", (x, 4), {}),
         ("rollaxis", (x, -1), {}),
-        pytest.param("roots", (x[:, 0],), {}),
+        pytest.param("roots", (x[:, 0],), {}, marks=xfail_quax58),
         ("rot90", (x,), {}),
         ("round", (x,), {}),
         # pytest.param("round_", (x,), {}, marks=pytest.mark.deprecated),
@@ -391,11 +405,11 @@ xbool = jnp.array([True, False, True], dtype=bool)
         pytest.param("searchsorted", (x,), {}, marks=mark_todo),
         pytest.param("select", (x,), {}, marks=mark_todo),
         *(
-            pytest.param("setdiff1d", (x[:, 0], y[:, 0]), {}),
+            pytest.param("setdiff1d", (x[:, 0], y[:, 0]), {}, marks=xfail_quax58),
             ("setdiff1d", (x[:, 0], y[:, 0]), {"size": x[:, 0].size}),
         ),
         *(
-            pytest.param("setxor1d", (x[:, 0], y[:, 0]), {}),
+            pytest.param("setxor1d", (x[:, 0], y[:, 0]), {}, marks=xfail_quax58),
             ("setxor1d", (x[:, 0], y[:, 0]), {"size": x[:, 0].size}),
         ),
         ("shape", (x,), {}),
@@ -426,7 +440,7 @@ xbool = jnp.array([True, False, True], dtype=bool)
         ("transpose", (x,), {}),
         ("tril", (jnp.eye(4),), {}),
         ("tril_indices_from", (jnp.eye(4),), {}),
-        (
+        pytest.param(
             "trim_zeros",
             (
                 jnp.concatenate(
@@ -434,6 +448,7 @@ xbool = jnp.array([True, False, True], dtype=bool)
                 ),
             ),
             {},
+            marks=xfail_quax58,
         ),
         ("triu", (x,), {}),
         ("triu_indices_from", (x,), {}),
@@ -441,27 +456,27 @@ xbool = jnp.array([True, False, True], dtype=bool)
         ("trunc", (x,), {}),
         pytest.param("ufunc", (x,), {}, marks=mark_todo),
         *(
-            pytest.param("union1d", (x[:, 0], y[:, 0]), {}),
+            pytest.param("union1d", (x[:, 0], y[:, 0]), {}, marks=xfail_quax58),
             ("union1d", (x[:, 0], y[:, 0]), {"size": x[:, 0].size}),
         ),
         *(
-            pytest.param("unique", (x,), {}),
+            pytest.param("unique", (x,), {}, marks=xfail_quax58),
             ("unique", (x,), {"size": x.size}),
         ),
         *(
-            pytest.param("unique_all", (x,), {}),
+            pytest.param("unique_all", (x,), {}, marks=xfail_quax58),
             ("unique_all", (x,), {"size": x.size}),
         ),
         *(
-            pytest.param("unique_counts", (x,), {}),
+            pytest.param("unique_counts", (x,), {}, marks=xfail_quax58),
             ("unique_counts", (x,), {"size": x.size}),
         ),
         *(
-            pytest.param("unique_inverse", (x,), {}),
+            pytest.param("unique_inverse", (x,), {}, marks=xfail_quax58),
             ("unique_inverse", (x,), {"size": x.size}),
         ),
         *(
-            pytest.param("unique_values", (x,), {}),
+            pytest.param("unique_values", (x,), {}, marks=xfail_quax58),
             ("unique_values", (x,), {"size": x.size}),
         ),
         pytest.param(


### PR DESCRIPTION
## Summary
- Backport of #203 to `versions/v0.10.x`.
- `hatchling>=1.32.0` now defaults to `Metadata-Version: 2.5`. The `Distribution build` CD check uses `hynek/build-and-inspect-python-package@v2.17.0`, which pins `twine==6.2.0`; that version monkeypatches `packaging.metadata._VALID_METADATA_VERSIONS` to a stale list that excludes `2.5`, so `twine check` rejects any wheel built with a recent hatchling. `twine==7.0.0` (pulled in by `build-and-inspect-python-package@v3.0.1`) drops that stale monkeypatch and natively supports metadata 2.5.
- Also backports #205 (jax 0.11.1 / ml_dtypes 0.6 fix): upstream jax released 0.11.1, and this branch's Python 3.12+ jobs started hitting the same `numpy/__init__.pyi: Invalid syntax` failure that #205 already fixed on `main`.
- Also backports #195 (`stack_p` primitive dispatch for `MyArray`, gated on `JAX_VERSION >= 0.10.1`) — `Newest supported deps` was hitting a `NotImplementedError` from `MyArray.materialise()` because `stack` had no MyArray-aware dispatch rule on this branch.
- Also addresses the `xfail_quax58` strict-XPASS failures `Newest supported deps` was hitting in `test_jax.py` (quax's JAX-input dispatch path fixed the underlying bug in quax 0.4.0). Unlike main (#197), which removed the mark outright because main's floor is `quax>=0.4.1`, this branch keeps `quax>=0.3.2` as the floor (raising it is out of scope for a patch branch), so the mark is instead **gated on the installed quax version** (`QUAX_VERSION < Version("0.4")`) — xfails under this branch's locked quax 0.3.2, doesn't under `Newest supported deps`'s quax 0.4.x. The `xfail_quax58` marks in `test_myarray.py` are untouched — they cover a separate, still-open MyArray-specific limitation.

## Test plan
- [x] Reproduced locally: built this repo's wheel (emits `Metadata-Version: 2.5`), confirmed `twine==6.2.0` fails `twine check` on it and `twine==7.0.0` passes.
- [x] Ran the full unit suite locally against the real locked/frozen deps (`uv run --frozen`, quax 0.3.2): 0 failures, `xfail_quax58` xfails as expected.
- [x] Ran the full unit suite locally against upgraded quax/jax/ml_dtypes/jaxlib (`uv run --upgrade-package ...`, quax 0.4.3): 0 failures, no XPASS.
- [x] `pre-commit`/`prek` hooks pass on all commits.
- [x] CI: `Distribution build` and `Newest supported deps` both pass; verifying the regular Python-version jobs now pass too after fixing an earlier bad assumption (see commit history).