### PR TITLE
🔒 security: bump transitive markdown for GHSA-5wmx-573v-2qwq

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,6 +257,7 @@ constraint-dependencies = [
   "bleach>6.0",
   "cffi>=1.14",
   "decorator>=5.1.1",
+  "markdown>=3.8.1",                         # GHSA-5wmx-573v-2qwq / CVE-2025-69534
   "matplotlib>=3.7.1",
   "matplotlib-inline>=0.1.6",
   "opt-einsum>=3.2.1",

--- a/uv.lock
+++ b/uv.lock
@@ -14,6 +14,7 @@ constraints = [
     { name = "bleach", specifier = ">6.0" },
     { name = "cffi", specifier = ">=1.14" },
     { name = "decorator", specifier = ">=5.1.1" },
+    { name = "markdown", specifier = ">=3.8.1" },
     { name = "matplotlib", specifier = ">=3.7.1" },
     { name = "matplotlib-inline", specifier = ">=0.1.6" },
     { name = "opt-einsum", specifier = ">=3.2.1" },
@@ -793,11 +794,11 @@ wheels = [
 
 [[package]]
 name = "markdown"
-version = "3.8"
+version = "3.10.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2f/15/222b423b0b88689c266d9eac4e61396fe2cc53464459d6a37618ac863b24/markdown-3.8.tar.gz", hash = "sha256:7df81e63f0df5c4b24b7d156eb81e4690595239b7d70937d0409f1b0de319c6f", size = 360906, upload-time = "2025-04-11T14:42:50.928Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/6f/da4c6aea59b3001f2e8c0ec7497475aadaf3b021c10cab5b2858f0f32b26/markdown-3.10.3.tar.gz", hash = "sha256:3589362618f743188b4d955b874402bc814f4f83f544dc207719f4baa7d9c45f", size = 372596, upload-time = "2026-07-30T19:05:29.005Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/3f/afe76f8e2246ffbc867440cbcf90525264df0e658f8a5ca1f872b3f6192a/markdown-3.8-py3-none-any.whl", hash = "sha256:794a929b79c5af141ef5ab0f2f642d0f7b1872981250230e72682346f7cc90dc", size = 106210, upload-time = "2025-04-11T14:42:49.178Z" },
+    { url = "https://files.pythonhosted.org/packages/64/69/4a5af2bc115a9a33fefe51709749de8262be3f9ba063d1753a837cdbc49c/markdown-3.10.3-py3-none-any.whl", hash = "sha256:fa6c92a00a4a3c98b22728c64a935ae1928250ae65058a6ded814d2cc29a4cea", size = 110757, upload-time = "2026-07-30T19:05:27.883Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Fixes [Dependabot alert #19](https://github.com/GalacticDynamics/quaxed/security/dependabot/19): `markdown` 3.8, pinned transitively via `uv.lock`, has an unhandled `AssertionError` in `HTMLParser` on malformed HTML-like input ([GHSA-5wmx-573v-2qwq](https://github.com/advisories/GHSA-5wmx-573v-2qwq) / CVE-2025-69534), fixed upstream in 3.8.1.

## Why constraint-dependencies

`markdown` isn't a direct dependency anywhere in `pyproject.toml` — it's pulled in by `mkdocs`/`mkdocstrings`/`pymdown-extensions`/`zensical` (all `docs` group, not runtime). No single direct dependency to bump, so this floors it the same way the repo already does for `tornado`, `scipy`, etc.: `[tool.uv] constraint-dependencies`.

Resolves to `markdown==3.10.3`.

## Verification

- `uv lock` resolves cleanly, `uv sync --locked` succeeds.
- `prek run --files pyproject.toml uv.lock` passes.
- `zensical build` (the docs build that actually exercises `markdown`) succeeds with the bumped version, no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)